### PR TITLE
Migrate first-run wizard to MVVM

### DIFF
--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
@@ -10,29 +10,37 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.viewpager.widget.ViewPager
 import app.quranhub.R
 import app.quranhub.data.Constants
-import app.quranhub.data.local.db.MushafDatabase
-import app.quranhub.data.local.db.RoomAsset
-import app.quranhub.data.local.prefs.AppPreferencesManager
 import app.quranhub.databinding.ActivityFirstTimeWizardBinding
 import app.quranhub.ui.base.BaseActivity
 import app.quranhub.ui.common.interfaces.Searchable
 import app.quranhub.ui.first_wizard.OptionsListFragment.OnOptionClickListener
 import app.quranhub.ui.main.MainActivity
 import app.quranhub.util.LocaleUtils.setAppLanguage
+import kotlinx.coroutines.launch
 
 class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
 
-    private var appLanguagesStepPosition = 0 // first step
-    private var translationLanguagesStepPosition = 1 // second step
-    private var recitationsStepPosition = 2 // third & last step
-    private var currentStepPosition = appLanguagesStepPosition
     private var binding: ActivityFirstTimeWizardBinding? = null
     private var wizardStepPagerAdapter: WizardStepPagerAdapter? = null
-    private val searchString = ""
-    var layoutDir = View.LAYOUT_DIRECTION_LTR
+    private var layoutDir = View.LAYOUT_DIRECTION_LTR
+    private var appliedSearchQuery: String? = null
+
+    private val viewModel: FirstTimeWizardViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                FirstTimeWizardViewModel(application)
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,22 +48,65 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         setContentView(binding!!.root)
         setSupportActionBar(binding!!.toolbar)
         layoutDir = resources.configuration.layoutDirection
-        if (layoutDir == View.LAYOUT_DIRECTION_RTL) {
-            initPagesPositionsForRtl()
-        }
-        if (savedInstanceState != null) {
-            currentStepPosition = savedInstanceState.getInt(STATE_CURRENT_STEP_POSITION)
-        }
         wizardStepPagerAdapter = WizardStepPagerAdapter(supportFragmentManager)
         binding!!.pagerSteps.adapter = wizardStepPagerAdapter
-        binding!!.pagerSteps.currentItem = appLanguagesStepPosition
-        updateViews(appLanguagesStepPosition)
-
-        // Initialize Mus'haf metadata DB
-        RoomAsset.initializeDatabase(
-            this, MushafDatabase.DATABASE_NAME, MushafDatabase.ASSET_DB_VERSION
-        )
+        binding!!.pagerSteps.currentItem = pagerIndexOfStep(viewModel.currentStep.value)
+        updateViews(viewModel.currentStep.value)
         attachListeners()
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.currentStep.collect { step ->
+                        val pagerIndex = pagerIndexOfStep(step)
+                        if (binding!!.pagerSteps.currentItem != pagerIndex) {
+                            binding!!.pagerSteps.currentItem = pagerIndex
+                        }
+                        updateViews(step)
+                    }
+                }
+                launch {
+                    viewModel.searchQuery.collect { query ->
+                        if (query != appliedSearchQuery) {
+                            appliedSearchQuery = query
+                            if (binding!!.etSearch.text.toString() != query) {
+                                if (query.isEmpty()) {
+                                    binding!!.etSearch.text.clear()
+                                    binding!!.etSearch.clearFocus()
+                                } else {
+                                    binding!!.etSearch.setText(query)
+                                }
+                            }
+                            searchOptions(query)
+                        }
+                    }
+                }
+                launch {
+                    viewModel.events.collect { event ->
+                        when (event) {
+                            is FirstTimeWizardViewModel.WizardEvent.AppLanguageChanged -> {
+                                // change app language & restart to apply it
+                                setAppLanguage(this@FirstTimeWizardActivity, event.langCode)
+                                restart()
+                            }
+
+                            is FirstTimeWizardViewModel.WizardEvent.WizardFinished -> {
+                                startActivity(
+                                    Intent(
+                                        this@FirstTimeWizardActivity,
+                                        MainActivity::class.java
+                                    )
+                                )
+                                finish()
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun attachListeners() {
@@ -68,14 +119,8 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
             }
 
             override fun onPageSelected(position: Int) {
-                // TODO apply MVP or MVVM
                 Log.d(TAG, "onPageSelected() callback called")
-                updateViews(position)
-                if (position != currentStepPosition) {
-                    // This is not a configuration change; you don't want to reset the search on config changes.
-                    resetSearch()
-                    currentStepPosition = position
-                }
+                viewModel.onStepSelected(stepOfPagerIndex(position))
             }
 
             override fun onPageScrollStateChanged(state: Int) {}
@@ -83,30 +128,27 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         binding!!.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                // TODO apply MVP or MVVM
-                searchOptions(s.toString())
+                viewModel.onSearchQueryChanged(s.toString())
             }
 
             override fun afterTextChanged(s: Editable) {}
         })
-        binding!!.btnBack.setOnClickListener { v: View? -> backButtonClicked() }
-        binding!!.btnNext.setOnClickListener { v: View? -> nextButtonClicked() }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putInt(STATE_CURRENT_STEP_POSITION, currentStepPosition)
+        binding!!.btnBack.setOnClickListener { backButtonClicked() }
+        binding!!.btnNext.setOnClickListener { nextButtonClicked() }
     }
 
     /**
-     * Modify pages position to allow correct RTL swiping.
+     * Maps a logical wizard step (0: first, 2: last) to its index in the view pager,
+     * which is reversed in RTL to allow correct swiping.
      */
-    private fun initPagesPositionsForRtl() {
-        appLanguagesStepPosition = 2 // first page for us, last page for the viewpager
-        translationLanguagesStepPosition = 1 // second page for us & the viewpager
-        recitationsStepPosition = 0 // third & last page for us, first page for the viewpager
-        currentStepPosition = appLanguagesStepPosition
-    }
+    private fun pagerIndexOfStep(step: Int): Int =
+        if (layoutDir == View.LAYOUT_DIRECTION_RTL) NUM_PAGES - 1 - step else step
+
+    /**
+     * Inverse of [pagerIndexOfStep].
+     */
+    private fun stepOfPagerIndex(pagerIndex: Int): Int =
+        if (layoutDir == View.LAYOUT_DIRECTION_RTL) NUM_PAGES - 1 - pagerIndex else pagerIndex
 
     private fun searchOptions(str: String) {
         val searchableFragment = wizardStepPagerAdapter?.currentFragment as? Searchable?
@@ -118,83 +160,57 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
     }
 
     override fun onBackPressed() {
-        if (binding!!.pagerSteps.currentItem == appLanguagesStepPosition) {
+        if (viewModel.currentStep.value == FirstTimeWizardViewModel.FIRST_STEP) {
             // If the user is currently looking at the first step, allow the system to handle the
             // Back button. This calls finish() on this activity and pops the back stack.
             super.onBackPressed()
         } else {
             // Otherwise, select the previous step.
-            openPreviousStepPage()
+            viewModel.onBackClicked()
         }
     }
 
     private fun backButtonClicked() {
-        // TODO apply MVP or MVVM
-        openPreviousStepPage()
+        viewModel.onBackClicked()
     }
 
     private fun nextButtonClicked() {
-        // TODO ally MVP or MVVM
-        openNextStepPage()
-    }
-
-    private fun openNextStepPage() {
-        var currentPageIndex = binding!!.pagerSteps.currentItem
-        if (layoutDir == View.LAYOUT_DIRECTION_LTR && currentPageIndex < NUM_PAGES - 1) {
-            // navigate to the next page
-            binding!!.pagerSteps.currentItem = ++currentPageIndex
-        } else if (layoutDir == View.LAYOUT_DIRECTION_RTL && currentPageIndex > 0) {
-            // navigate to the next page
-            binding!!.pagerSteps.currentItem = --currentPageIndex
-        } else {
-            finishWizard()
+        if (viewModel.currentStep.value == FirstTimeWizardViewModel.LAST_STEP) {
+            // disable the button while finishing to avoid duplicate clicks
+            binding!!.btnNext.isEnabled = false
         }
+        viewModel.onNextClicked()
     }
 
-    private fun openPreviousStepPage() {
-        var currentPageIndex = binding!!.pagerSteps.currentItem
-        if (layoutDir == View.LAYOUT_DIRECTION_LTR && currentPageIndex > 0) {
-            // navigate to the previous page
-            binding!!.pagerSteps.currentItem = --currentPageIndex
-        } else if (layoutDir == View.LAYOUT_DIRECTION_RTL && currentPageIndex < NUM_PAGES - 1) {
-            // navigate to the previous page
-            binding!!.pagerSteps.currentItem = ++currentPageIndex
-        }
-    }
-
-    /**
-     * Navigate to main activity and mark wizard as done
-     */
-    private fun finishWizard() {
-        binding!!.btnNext.isEnabled = false
-        AppPreferencesManager.markFirstTimeWizardDone(this)
-        startActivity(Intent(this, MainActivity::class.java))
-        finish()
-    }
-
-    private fun updateViews(currentStepPageIndex: Int) {
+    private fun updateViews(currentStep: Int) {
 
         // update the step hint
-        if (currentStepPageIndex == appLanguagesStepPosition) {
-            title = getString(R.string.first_wizard_title_app_language_step)
-            binding!!.tvStepHint.setText(R.string.first_wizard_hint_app_langauge)
-        } else if (currentStepPageIndex == translationLanguagesStepPosition) {
-            title = getString(R.string.first_wizard_title_translation_languages_step)
-            binding!!.tvStepHint.text = getString(R.string.first_wizard_hint_translation_languages)
-        } else if (currentStepPageIndex == recitationsStepPosition) {
-            title = getString(R.string.first_wizard_title_recitations_step)
-            binding!!.tvStepHint.text = getString(R.string.first_wizard_hint_recitations)
+        when (currentStep) {
+            FirstTimeWizardViewModel.FIRST_STEP -> {
+                title = getString(R.string.first_wizard_title_app_language_step)
+                binding!!.tvStepHint.setText(R.string.first_wizard_hint_app_langauge)
+            }
+
+            FirstTimeWizardViewModel.TRANSLATIONS_STEP -> {
+                title = getString(R.string.first_wizard_title_translation_languages_step)
+                binding!!.tvStepHint.text = getString(R.string.first_wizard_hint_translation_languages)
+            }
+
+            FirstTimeWizardViewModel.LAST_STEP -> {
+                title = getString(R.string.first_wizard_title_recitations_step)
+                binding!!.tvStepHint.text = getString(R.string.first_wizard_hint_recitations)
+            }
         }
 
         // update progress
-        showStepProgress(currentStepPageIndex)
+        showStepProgress(currentStep)
 
         // update buttons
-        if (currentStepPageIndex == recitationsStepPosition) {
+        if (currentStep == FirstTimeWizardViewModel.LAST_STEP) {
             // on last page
             binding!!.btnNext.setText(R.string.finish)
             binding!!.btnBack.isEnabled = true
-        } else if (currentStepPageIndex == appLanguagesStepPosition) {
+        } else if (currentStep == FirstTimeWizardViewModel.FIRST_STEP) {
             // on first page
             binding!!.btnNext.setText(R.string.next)
             binding!!.btnBack.isEnabled = false
@@ -205,15 +221,9 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         }
     }
 
-    private fun resetSearch() {
-        binding!!.etSearch.text.clear()
-        binding!!.etSearch.clearFocus()
-        searchOptions("")
-    }
-
-    private fun showStepProgress(currentStepPageIndex: Int) {
-        when (currentStepPageIndex) {
-            appLanguagesStepPosition -> {
+    private fun showStepProgress(currentStep: Int) {
+        when (currentStep) {
+            FirstTimeWizardViewModel.FIRST_STEP -> {
                 // first step
                 binding!!.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
                 binding!!.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
@@ -225,7 +235,7 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
                 binding!!.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_unchecked)
             }
 
-            translationLanguagesStepPosition -> {
+            FirstTimeWizardViewModel.TRANSLATIONS_STEP -> {
                 // second step
                 binding!!.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
                 binding!!.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
@@ -237,7 +247,7 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
                 binding!!.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_unchecked)
             }
 
-            recitationsStepPosition -> {
+            FirstTimeWizardViewModel.LAST_STEP -> {
                 // last (third) step
                 binding!!.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
                 binding!!.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
@@ -252,25 +262,12 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
     }
 
     override fun onOptionClicked(requestCode: Int, option: String, position: Int) {
-        // TODO apply MVP or MVVM
         when (requestCode) {
-            RC_APP_LANGUAGES_STEP -> {
-                val selectedLangCode = Constants.Language.CODES[position]
-                if (selectedLangCode != AppPreferencesManager.getAppLangSetting(this)) {
-                    AppPreferencesManager.persistAppLangSetting(this, selectedLangCode)
-                    setAppLanguage(this, selectedLangCode)
-                    restart()
-                }
-            }
+            RC_APP_LANGUAGES_STEP -> viewModel.onAppLanguageSelected(position)
 
-            RC_TRANSLATION_LANGUAGES_STEP -> {
-                val selectedTransLangCode = Constants.Language.CODES[position]
-                AppPreferencesManager.persistQuranTranslationLanguage(this, selectedTransLangCode)
-            }
+            RC_TRANSLATION_LANGUAGES_STEP -> viewModel.onTranslationLanguageSelected(position)
 
-            RC_RECITATIONS_STEP -> {
-                AppPreferencesManager.persistRecitationSetting(this, position)
-            }
+            RC_RECITATIONS_STEP -> viewModel.onRecitationSelected(position)
         }
     }
 
@@ -282,40 +279,32 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
             private set
 
         override fun getItem(position: Int): Fragment {
-            return when (position) {
-                appLanguagesStepPosition -> {
-                    val selectedAppLanguageIndex = Constants.Language.CODES.indexOf(
-                        AppPreferencesManager.getAppLangSetting(this@FirstTimeWizardActivity)
-                    )
+            return when (stepOfPagerIndex(position)) {
+                FirstTimeWizardViewModel.FIRST_STEP -> {
                     OptionsListFragment.newInstance(
                         this@FirstTimeWizardActivity,
                         Constants.Language.NAMES_STR_IDS,
                         Constants.Language.FLAGS_DRAWABLE_IDS,
-                        selectedAppLanguageIndex,
+                        viewModel.uiState.value.appLangIndex,
                         RC_APP_LANGUAGES_STEP
                     )
                 }
 
-                translationLanguagesStepPosition -> {
-                    val selectedTranslationLanguageIndex = Constants.Language.CODES.indexOf(
-                        AppPreferencesManager.getQuranTranslationLanguage(this@FirstTimeWizardActivity)
-                    )
+                FirstTimeWizardViewModel.TRANSLATIONS_STEP -> {
                     OptionsListFragment.newInstance(
                         this@FirstTimeWizardActivity,
                         Constants.Language.NAMES_STR_IDS,
                         Constants.Language.FLAGS_DRAWABLE_IDS,
-                        selectedTranslationLanguageIndex,
+                        viewModel.uiState.value.translationLangIndex,
                         RC_TRANSLATION_LANGUAGES_STEP
                     )
                 }
 
-                recitationsStepPosition -> {
-                    val selectedRecitationIndex =
-                        AppPreferencesManager.getRecitationSetting(this@FirstTimeWizardActivity)
+                FirstTimeWizardViewModel.LAST_STEP -> {
                     OptionsListFragment.newInstance(
                         this@FirstTimeWizardActivity,
                         Constants.Recitation.NAMES_STR_IDS,
-                        selectedRecitationIndex,
+                        viewModel.uiState.value.recitationIndex,
                         RC_RECITATIONS_STEP
                     )
                 }
@@ -338,8 +327,6 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
 
     companion object {
         private val TAG = FirstTimeWizardActivity::class.java.simpleName
-
-        private const val STATE_CURRENT_STEP_POSITION = "STATE_CURRENT_STEP_POSITION"
 
         private const val RC_APP_LANGUAGES_STEP = 0
         private const val RC_TRANSLATION_LANGUAGES_STEP = 1

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
@@ -21,7 +21,6 @@ import app.quranhub.R
 import app.quranhub.data.Constants
 import app.quranhub.databinding.ActivityFirstTimeWizardBinding
 import app.quranhub.ui.base.BaseActivity
-import app.quranhub.ui.common.interfaces.Searchable
 import app.quranhub.ui.first_wizard.OptionsListFragment.OnOptionClickListener
 import app.quranhub.ui.main.MainActivity
 import app.quranhub.util.LocaleUtils.setAppLanguage
@@ -70,6 +69,8 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
                 }
                 launch {
                     viewModel.searchQuery.collect { query ->
+                        // keep the search box in sync; each fragment applies the
+                        // query to its own options list
                         if (query != appliedSearchQuery) {
                             appliedSearchQuery = query
                             if (binding!!.etSearch.text.toString() != query) {
@@ -80,7 +81,6 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
                                     binding!!.etSearch.setText(query)
                                 }
                             }
-                            searchOptions(query)
                         }
                     }
                 }
@@ -149,15 +149,6 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
      */
     private fun stepOfPagerIndex(pagerIndex: Int): Int =
         if (layoutDir == View.LAYOUT_DIRECTION_RTL) NUM_PAGES - 1 - pagerIndex else pagerIndex
-
-    private fun searchOptions(str: String) {
-        val searchableFragment = wizardStepPagerAdapter?.currentFragment as? Searchable?
-        searchableFragment?.search(str)
-            ?: Log.e(
-                TAG,
-                "Couldn't search the options list as the current view pager fragment is null"
-            )
-    }
 
     override fun onBackPressed() {
         if (viewModel.currentStep.value == FirstTimeWizardViewModel.FIRST_STEP) {

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
@@ -328,9 +328,9 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
     companion object {
         private val TAG = FirstTimeWizardActivity::class.java.simpleName
 
-        private const val RC_APP_LANGUAGES_STEP = 0
-        private const val RC_TRANSLATION_LANGUAGES_STEP = 1
-        private const val RC_RECITATIONS_STEP = 2
+        const val RC_APP_LANGUAGES_STEP = 0
+        const val RC_TRANSLATION_LANGUAGES_STEP = 1
+        const val RC_RECITATIONS_STEP = 2
 
         private const val NUM_PAGES = 3
     }

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardViewModel.kt
@@ -85,7 +85,7 @@ class FirstTimeWizardViewModel(application: Application) : AndroidViewModel(appl
 
     fun onNextClicked() {
         if (_currentStep.value < LAST_STEP) {
-            _currentStep.value++
+            onStepSelected(_currentStep.value + 1)
         } else {
             finishWizard()
         }
@@ -93,7 +93,7 @@ class FirstTimeWizardViewModel(application: Application) : AndroidViewModel(appl
 
     fun onBackClicked() {
         if (_currentStep.value > FIRST_STEP) {
-            _currentStep.value--
+            onStepSelected(_currentStep.value - 1)
         }
     }
 

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardViewModel.kt
@@ -109,9 +109,11 @@ class FirstTimeWizardViewModel(application: Application) : AndroidViewModel(appl
 
     fun onAppLanguageSelected(itemIndex: Int) {
         val selectedLangCode = Constants.Language.CODES[itemIndex]
+        // always mirror the UI selection, even when the language didn't change,
+        // so the selection survives configuration changes
+        _uiState.update { it.copy(appLangIndex = itemIndex) }
         if (selectedLangCode != AppPreferencesManager.getAppLangSetting(context)) {
             AppPreferencesManager.persistAppLangSetting(context, selectedLangCode)
-            _uiState.update { it.copy(appLangIndex = itemIndex) }
             viewModelScope.launch {
                 _events.send(WizardEvent.AppLanguageChanged(selectedLangCode))
             }

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardViewModel.kt
@@ -1,0 +1,138 @@
+package app.quranhub.ui.first_wizard
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.quranhub.data.Constants
+import app.quranhub.data.local.db.MushafDatabase
+import app.quranhub.data.local.db.RoomAsset
+import app.quranhub.data.local.prefs.AppPreferencesManager
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class FirstTimeWizardViewModel(application: Application) : AndroidViewModel(application) {
+
+    sealed interface WizardEvent {
+        data class AppLanguageChanged(val langCode: String) : WizardEvent
+        data object WizardFinished : WizardEvent
+    }
+
+    data class WizardUiState(
+        val appLangIndex: Int = -1,
+        val translationLangIndex: Int = -1,
+        val recitationIndex: Int = 0,
+    )
+
+    private val context: Application = application
+
+    private val _uiState = MutableStateFlow(WizardUiState())
+    val uiState: StateFlow<WizardUiState> = _uiState.asStateFlow()
+
+    /**
+     * The logical step the wizard is currently showing
+     * (0: app language, 1: translation languages, 2: recitations),
+     * preserved across configuration changes.
+     */
+    private val _currentStep = MutableStateFlow(FIRST_STEP)
+    val currentStep: StateFlow<Int> = _currentStep.asStateFlow()
+
+    /** The current options-list search query, preserved across configuration changes. */
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private val _events = Channel<WizardEvent>(Channel.BUFFERED)
+    val events: Flow<WizardEvent> = _events.receiveAsFlow()
+
+    init {
+        // Initialize Mus'haf metadata DB. This runs once per wizard instance
+        // (the ViewModel survives configuration changes) and RoomAsset itself
+        // short-circuits if the DB is already up to date.
+        RoomAsset.initializeDatabase(
+            context, MushafDatabase.DATABASE_NAME, MushafDatabase.ASSET_DB_VERSION
+        )
+        loadSelectedOptions()
+    }
+
+    private fun loadSelectedOptions() {
+        _uiState.value = WizardUiState(
+            appLangIndex = Constants.Language.CODES.indexOf(
+                AppPreferencesManager.getAppLangSetting(context)
+            ),
+            translationLangIndex = Constants.Language.CODES.indexOf(
+                AppPreferencesManager.getQuranTranslationLanguage(context)
+            ),
+            recitationIndex = AppPreferencesManager.getRecitationSetting(context),
+        )
+    }
+
+    fun onStepSelected(step: Int) {
+        if (_currentStep.value != step) {
+            _currentStep.value = step
+            // Navigating to a different step resets the search.
+            _searchQuery.value = ""
+        }
+    }
+
+    fun onSearchQueryChanged(query: String) {
+        _searchQuery.value = query
+    }
+
+    fun onNextClicked() {
+        if (_currentStep.value < LAST_STEP) {
+            _currentStep.value++
+        } else {
+            finishWizard()
+        }
+    }
+
+    fun onBackClicked() {
+        if (_currentStep.value > FIRST_STEP) {
+            _currentStep.value--
+        }
+    }
+
+    /**
+     * Navigate to main activity and mark wizard as done.
+     */
+    private fun finishWizard() {
+        AppPreferencesManager.markFirstTimeWizardDone(context)
+        viewModelScope.launch {
+            _events.send(WizardEvent.WizardFinished)
+        }
+    }
+
+    fun onAppLanguageSelected(itemIndex: Int) {
+        val selectedLangCode = Constants.Language.CODES[itemIndex]
+        if (selectedLangCode != AppPreferencesManager.getAppLangSetting(context)) {
+            AppPreferencesManager.persistAppLangSetting(context, selectedLangCode)
+            _uiState.update { it.copy(appLangIndex = itemIndex) }
+            viewModelScope.launch {
+                _events.send(WizardEvent.AppLanguageChanged(selectedLangCode))
+            }
+        }
+    }
+
+    fun onTranslationLanguageSelected(itemIndex: Int) {
+        AppPreferencesManager.persistQuranTranslationLanguage(
+            context, Constants.Language.CODES[itemIndex]
+        )
+        _uiState.update { it.copy(translationLangIndex = itemIndex) }
+    }
+
+    fun onRecitationSelected(itemIndex: Int) {
+        AppPreferencesManager.persistRecitationSetting(context, itemIndex)
+        _uiState.update { it.copy(recitationIndex = itemIndex) }
+    }
+
+    companion object {
+        const val FIRST_STEP = 0 // app language step
+        const val TRANSLATIONS_STEP = 1 // translation languages step
+        const val LAST_STEP = 2 // recitations step
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListAdapter.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListAdapter.kt
@@ -110,53 +110,32 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
     }
 
     override fun getFilter(): Filter {
-        // TODO refactor & enhance Filter
         return object : Filter() {
             override fun performFiltering(constraint: CharSequence): FilterResults {
-                var filterOptionsResult: MutableList<String> = ArrayList()
-                var filterThumbnailsResult: MutableList<Int?>? = null
-                if (constraint.length == 0) {
-                    filterOptionsResult = optionsList
-                    if (optionsThumbnailsDrawableIds != null) {
-                        filterThumbnailsResult = ArrayList()
-                        for (d in optionsThumbnailsDrawableIds!!) {
-                            filterThumbnailsResult.add(d)
-                        }
-                    }
+                val query = constraint.toString().lowercase(Locale.getDefault())
+                val filteredOptions: List<String>
+                val filteredThumbnails: List<Int>?
+                if (query.isEmpty()) {
+                    filteredOptions = optionsList
+                    filteredThumbnails = optionsThumbnailsDrawableIds?.toList()
                 } else {
-                    if (optionsThumbnailsDrawableIds != null) {
-                        filterThumbnailsResult = ArrayList()
+                    val matches = optionsList.withIndex().filter { (_, option) ->
+                        option.lowercase(Locale.getDefault()).contains(query)
                     }
-                    for (i in optionsList.indices) {
-                        val opt = optionsList[i]
-                        if (opt.lowercase(Locale.getDefault()).contains(
-                                constraint.toString().lowercase(
-                                    Locale.getDefault()
-                                )
-                            )
-                        ) {
-                            filterOptionsResult.add(opt)
-                            filterThumbnailsResult?.add(optionsThumbnailsDrawableIds!![i])
-                        }
+                    filteredOptions = matches.map { it.value }
+                    filteredThumbnails = optionsThumbnailsDrawableIds?.let { thumbnails ->
+                        matches.map { thumbnails[it.index] }
                     }
                 }
                 val results = FilterResults()
-                results.values =
-                    Pair<List<String>, List<Int?>?>(filterOptionsResult, filterThumbnailsResult)
+                results.values = Pair(filteredOptions, filteredThumbnails)
                 return results
             }
 
             override fun publishResults(constraint: CharSequence, results: FilterResults) {
                 val filterResult = results.values as Pair<List<String>, List<Int>?>
                 filteredOptionsList = filterResult.first
-                if (filterResult.second != null) {
-                    filteredOptionsThumbnailsDrawableIds = IntArray(filterResult.second!!.size)
-                    for (i in filterResult.second!!.indices) {
-                        filteredOptionsThumbnailsDrawableIds!![i] = filterResult.second!![i]
-                    }
-                } else {
-                    filteredOptionsThumbnailsDrawableIds = null
-                }
+                filteredOptionsThumbnailsDrawableIds = filterResult.second?.toIntArray()
                 notifyDataSetChanged()
             }
         }

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListAdapter.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListAdapter.kt
@@ -1,6 +1,5 @@
 package app.quranhub.ui.first_wizard
 
-import android.util.Pair
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,15 +13,19 @@ import java.util.Locale
 class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, Filterable {
 
     private var optionsList: MutableList<String>
-    private var filteredOptionsList: List<String>
     private var optionsThumbnailsDrawableIds: IntArray? = null
-    private var filteredOptionsThumbnailsDrawableIds: IntArray? = null
+
+    /**
+     * The indices (into [optionsList]) of the options shown after filtering,
+     * so a filtered view position can always be mapped back to its original option.
+     */
+    private var filteredOriginalIndices: List<Int>
     private var selectedOptionIndex: Int
     private var itemClickListener: ItemClickListener
 
     constructor(optionsList: MutableList<String>, listener: ItemClickListener) {
         this.optionsList = optionsList
-        filteredOptionsList = optionsList
+        filteredOriginalIndices = optionsList.indices.toList()
         itemClickListener = listener
         selectedOptionIndex = -1
     }
@@ -31,7 +34,7 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
         optionsList: MutableList<String>, selectedOptionIndex: Int, listener: ItemClickListener
     ) {
         this.optionsList = optionsList
-        filteredOptionsList = optionsList
+        filteredOriginalIndices = optionsList.indices.toList()
         this.selectedOptionIndex = selectedOptionIndex
         itemClickListener = listener
     }
@@ -43,9 +46,8 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
         listener: ItemClickListener
     ) {
         this.optionsList = optionsList.toMutableList()
-        filteredOptionsList = optionsList
+        filteredOriginalIndices = optionsList.indices.toList()
         this.optionsThumbnailsDrawableIds = optionsThumbnailsDrawableIds
-        filteredOptionsThumbnailsDrawableIds = optionsThumbnailsDrawableIds
         this.selectedOptionIndex = selectedOptionIndex
         itemClickListener = listener
     }
@@ -56,7 +58,7 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
 
     fun setOptionsList(optionsList: MutableList<String>) {
         this.optionsList = optionsList
-        filteredOptionsList = optionsList
+        filteredOriginalIndices = optionsList.indices.toList()
         notifyDataSetChanged()
     }
 
@@ -64,9 +66,8 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
         optionsList: MutableList<String>, optionsThumbnailsDrawableIds: IntArray?
     ) {
         this.optionsList = optionsList
-        filteredOptionsList = optionsList
+        filteredOriginalIndices = optionsList.indices.toList()
         this.optionsThumbnailsDrawableIds = optionsThumbnailsDrawableIds
-        filteredOptionsThumbnailsDrawableIds = optionsThumbnailsDrawableIds
         notifyDataSetChanged()
     }
 
@@ -89,16 +90,17 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        if (filteredOptionsThumbnailsDrawableIds != null) {
-            val drawableResId = filteredOptionsThumbnailsDrawableIds!![position]
+        val originalIndex = filteredOriginalIndices[position]
+        if (optionsThumbnailsDrawableIds != null) {
             holder.binding.ivOptionThumbnail.visibility = View.VISIBLE
-            holder.binding.ivOptionThumbnail.setImageResource(drawableResId)
+            holder.binding.ivOptionThumbnail.setImageResource(
+                optionsThumbnailsDrawableIds!![originalIndex]
+            )
         } else {
             holder.binding.ivOptionThumbnail.visibility = View.GONE
         }
-        val option = filteredOptionsList[position]
-        holder.binding.tvOptionName.text = option
-        if (position == selectedOptionIndex) {
+        holder.binding.tvOptionName.text = optionsList[originalIndex]
+        if (originalIndex == selectedOptionIndex) {
             holder.binding.ivCheckBox.visibility = View.VISIBLE
         } else {
             holder.binding.ivCheckBox.visibility = View.INVISIBLE
@@ -106,36 +108,29 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
     }
 
     override fun getItemCount(): Int {
-        return filteredOptionsList.size
+        return filteredOriginalIndices.size
     }
 
     override fun getFilter(): Filter {
         return object : Filter() {
             override fun performFiltering(constraint: CharSequence): FilterResults {
                 val query = constraint.toString().lowercase(Locale.getDefault())
-                val filteredOptions: List<String>
-                val filteredThumbnails: List<Int>?
-                if (query.isEmpty()) {
-                    filteredOptions = optionsList
-                    filteredThumbnails = optionsThumbnailsDrawableIds?.toList()
+                val matchedIndices = if (query.isEmpty()) {
+                    optionsList.indices.toList()
                 } else {
-                    val matches = optionsList.withIndex().filter { (_, option) ->
-                        option.lowercase(Locale.getDefault()).contains(query)
-                    }
-                    filteredOptions = matches.map { it.value }
-                    filteredThumbnails = optionsThumbnailsDrawableIds?.let { thumbnails ->
-                        matches.map { thumbnails[it.index] }
-                    }
+                    optionsList.withIndex()
+                        .filter { (_, option) ->
+                            option.lowercase(Locale.getDefault()).contains(query)
+                        }
+                        .map { it.index }
                 }
                 val results = FilterResults()
-                results.values = Pair(filteredOptions, filteredThumbnails)
+                results.values = matchedIndices
                 return results
             }
 
             override fun publishResults(constraint: CharSequence, results: FilterResults) {
-                val filterResult = results.values as Pair<List<String>, List<Int>?>
-                filteredOptionsList = filterResult.first
-                filteredOptionsThumbnailsDrawableIds = filterResult.second?.toIntArray()
+                filteredOriginalIndices = results.values as List<Int>
                 notifyDataSetChanged()
             }
         }
@@ -151,8 +146,9 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
         }
 
         override fun onClick(v: View) {
-            setSelectedOptionIndex(adapterPosition)
-            itemClickListener.onItemClick(selectedOptionIndex)
+            val originalIndex = filteredOriginalIndices[adapterPosition]
+            setSelectedOptionIndex(originalIndex)
+            itemClickListener.onItemClick(originalIndex)
         }
     }
 

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,6 +27,7 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
     private lateinit var options: List<String>
     private var optionsThumbnailsDrawableIds: IntArray? = null
     private var selectedOptionPosition = 0
+    private val viewModel: FirstTimeWizardViewModel by activityViewModels()
     private var listener: OnOptionClickListener? = null
     private var optionsListAdapter: OptionsListAdapter? = null
     private var searchText: String? = ""
@@ -80,9 +82,27 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
         )
         binding!!.rvOptions.addItemDecoration(dividerItemDecoration)
         optionsListAdapter = OptionsListAdapter(
-            options, optionsThumbnailsDrawableIds, selectedOptionPosition, this
+            options, optionsThumbnailsDrawableIds, currentSelectedOptionIndex(), this
         )
         binding!!.rvOptions.adapter = optionsListAdapter
+    }
+
+    /**
+     * The currently selected option index for this step. Read from the shared
+     * wizard ViewModel so a restored fragment (whose arguments are frozen at
+     * creation time) still reflects selections made before a configuration change.
+     */
+    private fun currentSelectedOptionIndex(): Int = when (requestCode) {
+        FirstTimeWizardActivity.RC_APP_LANGUAGES_STEP ->
+            viewModel.uiState.value.appLangIndex
+
+        FirstTimeWizardActivity.RC_TRANSLATION_LANGUAGES_STEP ->
+            viewModel.uiState.value.translationLangIndex
+
+        FirstTimeWizardActivity.RC_RECITATIONS_STEP ->
+            viewModel.uiState.value.recitationIndex
+
+        else -> selectedOptionPosition
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
@@ -7,12 +7,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import app.quranhub.databinding.FragmentOptionsListBinding
 import app.quranhub.ui.common.interfaces.Searchable
 import app.quranhub.ui.first_wizard.OptionsListFragment.OnOptionClickListener
+import kotlinx.coroutines.launch
 
 /**
  * Activities that contain this fragment must implement the
@@ -51,6 +55,27 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
         binding = FragmentOptionsListBinding.inflate(inflater, container, false)
         initOptionsRecyclerView()
         return binding!!.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeSelectedOption()
+    }
+
+    private fun observeSelectedOption() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    // Converge the checkmark to the shared wizard state; this also
+                    // restores the selection after a configuration change.
+                    val index = selectedIndexFrom(state)
+                    val adapter = optionsListAdapter
+                    if (adapter != null && index != adapter.getSelectedOptionIndex()) {
+                        adapter.setSelectedOptionIndex(index)
+                    }
+                }
+            }
+        }
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -92,18 +117,18 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
      * wizard ViewModel so a restored fragment (whose arguments are frozen at
      * creation time) still reflects selections made before a configuration change.
      */
-    private fun currentSelectedOptionIndex(): Int = when (requestCode) {
-        FirstTimeWizardActivity.RC_APP_LANGUAGES_STEP ->
-            viewModel.uiState.value.appLangIndex
+    private fun currentSelectedOptionIndex(): Int = selectedIndexFrom(viewModel.uiState.value)
 
-        FirstTimeWizardActivity.RC_TRANSLATION_LANGUAGES_STEP ->
-            viewModel.uiState.value.translationLangIndex
+    private fun selectedIndexFrom(state: FirstTimeWizardViewModel.WizardUiState): Int =
+        when (requestCode) {
+            FirstTimeWizardActivity.RC_APP_LANGUAGES_STEP -> state.appLangIndex
 
-        FirstTimeWizardActivity.RC_RECITATIONS_STEP ->
-            viewModel.uiState.value.recitationIndex
+            FirstTimeWizardActivity.RC_TRANSLATION_LANGUAGES_STEP -> state.translationLangIndex
 
-        else -> selectedOptionPosition
-    }
+            FirstTimeWizardActivity.RC_RECITATIONS_STEP -> state.recitationIndex
+
+            else -> selectedOptionPosition
+        }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
@@ -60,6 +60,7 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         observeSelectedOption()
+        observeSearchQuery()
     }
 
     private fun observeSelectedOption() {
@@ -73,6 +74,18 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
                     if (adapter != null && index != adapter.getSelectedOptionIndex()) {
                         adapter.setSelectedOptionIndex(index)
                     }
+                }
+            }
+        }
+    }
+
+    private fun observeSearchQuery() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.searchQuery.collect { query ->
+                    // Mirror the shared search query so a revisited step never
+                    // keeps a stale filter from an earlier visit.
+                    optionsListAdapter?.filter?.filter(query)
                 }
             }
         }


### PR DESCRIPTION
Closes #257 (parent #247)

## What

- New `FirstTimeWizardViewModel` (`AndroidViewModel` + `StateFlow`/`Channel`, matching the established `SettingsViewModel` pattern) owns:
  - Mushaf metadata DB bootstrap via `RoomAsset.initializeDatabase` — runs once per wizard instance, so a rotated/recreated activity never re-runs it (and `RoomAsset` itself short-circuits if the DB is already current).
  - Preference setup (app language, translation language, recitation).
  - Step progression state + search query, both preserved across configuration changes.
- `FirstTimeWizardActivity` becomes a thin view: it maps logical wizard steps ↔ view pager indices (handling the RTL reversal that previously lived in `initPagesPositionsForRtl`), renders state and reacts to events (`AppLanguageChanged` → locale change + restart, `WizardFinished` → MainActivity + finish).
- All in-view TODO markers on this screen resolved: the five "apply MVP or MVVM" TODOs in the activity, and `OptionsListAdapter`'s "TODO refactor & enhance Filter" (filter rewritten idiomatically).

## Verification

- `./gradlew build` green (exactly what CI runs).
- Manual smoke test still to do by a human: fresh app data → walk the wizard, rotate mid-step, complete, verify no re-run on next launch.