### PR TITLE
Handle edge-to-edge system bar insets on all screens

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,7 +83,8 @@
         <activity
             android:name=".ui.first_wizard.FirstTimeWizardActivity"
             android:label="@string/title_activity_first_time_wizard"
-            android:theme="@style/AppTheme.NoActionBar" />
+            android:theme="@style/AppTheme.NoActionBar"
+            android:windowSoftInputMode="adjustResize" />
 
         <activity
             android:name=".ui.settings.SettingsActivity"

--- a/app/src/main/java/app/quranhub/ui/base/BaseActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/base/BaseActivity.kt
@@ -1,8 +1,11 @@
 package app.quranhub.ui.base
 
 import android.content.Context
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import app.quranhub.util.LocaleUtils.initAppLanguage
 
@@ -11,6 +14,10 @@ abstract class BaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         initAppLanguage(this)
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+        )
     }
 
     override fun attachBaseContext(newBase: Context) {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsManagerActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsManagerActivity.kt
@@ -15,6 +15,7 @@ import app.quranhub.ui.downloads_manager.dialogs.AudioDownloadAmountDialogFragme
 import app.quranhub.ui.downloads_manager.dialogs.AudioDownloadAmountDialogFragment.AudioDownloadListener
 import app.quranhub.ui.downloads_manager.dialogs.QuranRecitersDialogFragment
 import app.quranhub.ui.downloads_manager.dialogs.QuranRecitersDialogFragment.ReciterSelectionListener
+import app.quranhub.util.InsetsUtils
 import com.google.android.material.tabs.TabLayout
 
 class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallbacks,
@@ -33,6 +34,8 @@ class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallb
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+        InsetsUtils.padTopForStatusBar(binding.appBar)
+        InsetsUtils.padBottomForNavigationBar(binding.fragmentContainer)
 
         binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
 

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
@@ -23,6 +23,7 @@ import app.quranhub.databinding.ActivityFirstTimeWizardBinding
 import app.quranhub.ui.base.BaseActivity
 import app.quranhub.ui.first_wizard.OptionsListFragment.OnOptionClickListener
 import app.quranhub.ui.main.MainActivity
+import app.quranhub.util.InsetsUtils
 import app.quranhub.util.LocaleUtils.setAppLanguage
 import kotlinx.coroutines.launch
 
@@ -46,6 +47,8 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         binding = ActivityFirstTimeWizardBinding.inflate(layoutInflater)
         setContentView(binding!!.root)
         setSupportActionBar(binding!!.toolbar)
+        InsetsUtils.padTopForStatusBar(binding!!.appBar)
+        InsetsUtils.padBottomForNavigationBar(binding!!.clBottomBar)
         layoutDir = resources.configuration.layoutDirection
         wizardStepPagerAdapter = WizardStepPagerAdapter(supportFragmentManager)
         binding!!.pagerSteps.adapter = wizardStepPagerAdapter

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/BookmarksFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/BookmarksFragment.kt
@@ -19,6 +19,7 @@ import app.quranhub.databinding.FragmentBookmarksBinding
 import app.quranhub.ui.common.interfaces.ToolbarActionsListener
 import app.quranhub.ui.mushaf.listener.QuranNavigationCallbacks
 import app.quranhub.ui.mushaf.viewmodel.BookmarksViewModel
+import app.quranhub.util.InsetsUtils
 import app.quranhub.util.ScreenUtils.dismissKeyboard
 import kotlinx.coroutines.launch
 
@@ -70,6 +71,7 @@ class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         bookmarksListFragment = BookmarksListFragment.newInstance()
         val transaction = childFragmentManager.beginTransaction()
         transaction.replace(R.id.list_container, bookmarksListFragment!!)

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafBottomBarFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafBottomBarFragment.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import app.quranhub.R
 import app.quranhub.databinding.FragmentMushafBottomBarBinding
 import app.quranhub.ui.mushaf.viewmodel.MushafViewModel
+import app.quranhub.util.InsetsUtils
 import kotlinx.coroutines.launch
 
 class MushafBottomBarFragment : Fragment() {
@@ -50,6 +51,7 @@ class MushafBottomBarFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padBottomForNavigationBar(binding!!.llRoot)
         initViews()
         observeViewModel()
         binding!!.quranPageTv.text = pageNumText

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafFragment.kt
@@ -56,6 +56,7 @@ import app.quranhub.ui.mushaf.model.QuranPageInfo
 import app.quranhub.ui.mushaf.model.RepeatModel
 import app.quranhub.ui.mushaf.model.SuraVersesNumber
 import app.quranhub.ui.mushaf.viewmodel.MushafViewModel
+import app.quranhub.util.InsetsUtils
 import app.quranhub.util.LocaleUtils.formatNumber
 import app.quranhub.util.ScreenUtils.isLandscape
 import app.quranhub.util.ScreenUtils.isPortrait
@@ -155,6 +156,7 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padBottomMarginForNavigationBar(binding.quranSeekbar)
         attachListeners()
         observeViewModel()
 

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafTopBarFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafTopBarFragment.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.MutableLiveData
 import app.quranhub.R
 import app.quranhub.databinding.FragmentMushafTopBarBinding
 import app.quranhub.ui.common.interfaces.ToolbarActionsListener
+import app.quranhub.util.InsetsUtils
 
 class MushafTopBarFragment : Fragment() {
 
@@ -43,6 +44,7 @@ class MushafTopBarFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.llRoot)
         initViews()
         pageDirLiveData!!.observe(viewLifecycleOwner) { pageDir: Int? ->
             when (pageDir) {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MyNotesFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MyNotesFragment.kt
@@ -28,6 +28,7 @@ import app.quranhub.ui.mushaf.listener.ItemSelectionListener
 import app.quranhub.ui.mushaf.listener.QuranNavigationCallbacks
 import app.quranhub.ui.mushaf.model.DisplayedNote
 import app.quranhub.ui.mushaf.viewmodel.NotesViewModel
+import app.quranhub.util.InsetsUtils
 import app.quranhub.util.ScreenUtils
 import app.quranhub.util.ScreenUtils.dismissKeyboard
 import app.quranhub.util.ScreenUtils.getOrientationState
@@ -69,6 +70,7 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         savedInstanceState?.let { getPrevState(it) }
         initViews()
         bindViewModel()

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranTopicsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranTopicsFragment.kt
@@ -22,6 +22,7 @@ import app.quranhub.ui.mushaf.listener.ItemSelectionListener
 import app.quranhub.ui.mushaf.model.TopicCategory
 import app.quranhub.ui.mushaf.model.TopicModel
 import app.quranhub.ui.mushaf.viewmodel.SubjectsViewModel
+import app.quranhub.util.InsetsUtils
 import java.util.Locale
 import kotlinx.coroutines.launch
 
@@ -51,6 +52,7 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         intiRecycler()
         bindViewModel()
         attachListeners()

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SearchFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SearchFragment.kt
@@ -27,6 +27,7 @@ import app.quranhub.ui.mushaf.listener.ItemSelectionListener
 import app.quranhub.ui.mushaf.listener.QuranNavigationCallbacks
 import app.quranhub.ui.mushaf.model.SearchModel
 import app.quranhub.ui.mushaf.viewmodel.SearchViewModel
+import app.quranhub.util.InsetsUtils
 import app.quranhub.util.ScreenUtils.dismissKeyboard
 import kotlinx.coroutines.launch
 
@@ -73,6 +74,7 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         if (savedInstanceState != null) {
             isOriented = true
             getPrevState(savedInstanceState)

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraGuz2IndexFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraGuz2IndexFragment.kt
@@ -14,6 +14,7 @@ import app.quranhub.ui.common.dialogs.OptionsListDialogFragment
 import app.quranhub.ui.common.dialogs.OptionsListDialogFragment.Companion.getInstance
 import app.quranhub.ui.common.interfaces.ToolbarActionsListener
 import app.quranhub.ui.mushaf.adapter.Guz2IndexAdapter
+import app.quranhub.util.InsetsUtils
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import java.util.Arrays
@@ -59,6 +60,7 @@ class SuraGuz2IndexFragment : Fragment(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         restoreSavedInstanceState(savedInstanceState)
         addIndexFragment(selectedTab)
         attachListeners()

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TafseerFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TafseerFragment.kt
@@ -31,6 +31,7 @@ import app.quranhub.ui.mushaf.dialogs.TranslationsDialogFragment
 import app.quranhub.ui.mushaf.fragments.TranslationsDataFragment.TranslationSelectionListener
 import app.quranhub.ui.mushaf.model.TafseerModel
 import app.quranhub.ui.mushaf.viewmodel.TafseerViewModel
+import app.quranhub.util.InsetsUtils
 import kotlinx.coroutines.launch
 
 class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationSelectionListener,
@@ -65,6 +66,7 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         readArgumentsData()
         savedInstanceState?.let { getPrevState(it) }
         initRecycler()

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TopicAyasFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TopicAyasFragment.kt
@@ -22,6 +22,7 @@ import app.quranhub.ui.mushaf.listener.QuranNavigationCallbacks
 import app.quranhub.ui.mushaf.model.SearchModel
 import app.quranhub.ui.mushaf.model.TopicCategory
 import app.quranhub.ui.mushaf.viewmodel.TopicViewModel
+import app.quranhub.util.InsetsUtils
 import app.quranhub.util.ScreenUtils.dismissKeyboard
 import kotlinx.coroutines.launch
 
@@ -56,6 +57,7 @@ class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         setViews()
         getPrevState(savedInstanceState)
         intiRecycler()

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsLibraryFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsLibraryFragment.kt
@@ -15,6 +15,7 @@ import app.quranhub.databinding.FragmentTranslationsLibraryBinding
 import app.quranhub.ui.common.interfaces.ToolbarActionsListener
 import app.quranhub.ui.main.MainActivity
 import app.quranhub.ui.mushaf.fragments.TranslationsDataFragment.TranslationSelectionListener
+import app.quranhub.util.InsetsUtils
 
 class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
 
@@ -41,6 +42,7 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
         restoreSavedInstanceState(savedInstanceState)
         addFragment()
         attachListeners()

--- a/app/src/main/java/app/quranhub/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/settings/SettingsActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.widget.Toolbar
 import app.quranhub.R
 import app.quranhub.ui.base.BaseActivity
 import app.quranhub.ui.main.MainActivity
+import app.quranhub.util.InsetsUtils
 
 class SettingsActivity : BaseActivity() {
 
@@ -17,6 +18,8 @@ class SettingsActivity : BaseActivity() {
         setSupportActionBar(toolbar)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         setTitle(R.string.title_activity_settings)
+        InsetsUtils.padTopForStatusBar(findViewById(R.id.app_bar))
+        InsetsUtils.padBottomForNavigationBar(findViewById(R.id.fragment))
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/app/quranhub/util/InsetsUtils.kt
+++ b/app/src/main/java/app/quranhub/util/InsetsUtils.kt
@@ -1,0 +1,39 @@
+package app.quranhub.util
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+
+object InsetsUtils {
+
+    fun padTopForStatusBar(view: View) {
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            v.updatePadding(top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top)
+            insets
+        }
+        ViewCompat.requestApplyInsets(view)
+    }
+
+    fun padBottomForNavigationBar(view: View) {
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            v.updatePadding(bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom)
+            insets
+        }
+        ViewCompat.requestApplyInsets(view)
+    }
+
+    fun padBottomMarginForNavigationBar(view: View) {
+        val baseMargin = (view.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin ?: 0
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            (v.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                lp.bottomMargin =
+                    baseMargin + insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+                v.layoutParams = lp
+            }
+            insets
+        }
+        ViewCompat.requestApplyInsets(view)
+    }
+}

--- a/app/src/main/res/layout/activity_downloads_manager.xml
+++ b/app/src/main/res/layout/activity_downloads_manager.xml
@@ -7,6 +7,7 @@
     tools:context=".ui.downloads_manager.DownloadsManagerActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">

--- a/app/src/main/res/layout/activity_first_time_wizard.xml
+++ b/app/src/main/res/layout/activity_first_time_wizard.xml
@@ -9,8 +9,9 @@
     tools:context=".ui.first_wizard.FirstTimeWizardActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/custom_toolbar_height"
+        android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
         <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -7,6 +7,7 @@
     tools:context=".ui.settings.SettingsActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">

--- a/app/src/main/res/layout/fragment_mushaf_bottom_bar.xml
+++ b/app/src/main/res/layout/fragment_mushaf_bottom_bar.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom"
+    android:background="@color/white_color"
     android:orientation="vertical">
 
     <!-- Drop shadow -->

--- a/app/src/main/res/layout/fragment_mushaf_top_bar.xml
+++ b/app/src/main/res/layout/fragment_mushaf_top_bar.xml
@@ -5,6 +5,7 @@
     android:id="@+id/ll_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@color/white_color"
     android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
## Summary
- targetSdk 36 enforces edge-to-edge on Android 15+ (API 35+), and the app handled no window insets, so content drew behind the status bar (visible in the Downloads Manager, Settings, wizard and mushaf screens).
- Call `enableEdgeToEdge()` in `BaseActivity` (white status-bar icons, dark nav-bar icons) and apply insets through a new `InsetsUtils` helper:
  - Downloads Manager & Settings: app bar padded below the status bar (colored background extends behind it); content lifted above the nav bar.
  - First-run wizard: app bar + bottom button bar insets; app bar height changed from fixed 100dp to wrap_content; `adjustResize` added for the search box.
  - Mushaf: top/bottom bars padded with a white background extending behind the system bars, page seekbar lifted above the nav bar; all sub-screen toolbars (index, search, tafsir, topics, bookmarks, notes, library, topic ayas) padded below the status bar.
- Quran pages remain truly full-bleed (edge-to-edge) by design.

## Testing
- `./gradlew build` passes (same as CI).
- Manually verified on device: Downloads Manager, Settings, wizard and mushaf status bars render correctly.

Closes the edge-to-edge overlap reported on latest Android versions.