### PR TITLE
Enable R8 minification and resource shrinking for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,21 +5,28 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Keep line numbers & file names so Crashlytics can symbolicate stack traces
+# (mapping.txt is uploaded automatically by the Firebase Crashlytics Gradle plugin).
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Needed for reflection over generics (Gson TypeToken, Retrofit call adapters,
+# FastAdapter/MaterialDrawer TypeUtils).
+-keepattributes Signature,InnerClasses,EnclosingMethod
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Gson deserializes these by reflection. Fields without @SerializedName must
+# keep their names, and Firestore's toObjects() resolves Kotlin data-class
+# getters/setters reflectively - so keep members of all POJOs.
+-keep class app.quranhub.data.model.** { *; }
+-keep class app.quranhub.data.remote.model.** { *; }
 
+# MaterialDrawer v6.1.3 does not ship consumer ProGuard rules.
+# (EventBus, Retrofit, Gson, RxJava2, Room, Glide and Firebase all bundle
+# their own consumer rules - no manual rules required for those.)
+-keep class com.mikepenz.materialdrawer.** { *; }
+-keep class com.mikepenz.fastadapter.** { *; }
+
+# circular-progress-button: field accessed reflectively by the library
 -keepclassmembers class com.dd.StrokeGradientDrawable {
     public void setStrokeColor(int);
 }


### PR DESCRIPTION
## Summary
- Enables R8 obfuscation/minification and resource shrinking for release builds (`isMinifyEnabled`, `isShrinkResources`).
- Adds ProGuard/R8 keep rules for code that relies on reflection, so the app doesn't break in production:
  - `app.quranhub.data.model` / `app.quranhub.data.remote.model` — Gson and Firestore POJOs deserialized reflectively (fields without `@SerializedName` would otherwise be renamed and silently deserialize to `null`).
  - `com.mikepenz.materialdrawer` / `com.mikepenz.fastadapter` — MaterialDrawer v6.1.3 ships no consumer rules.
  - `SourceFile,LineNumberTable` attributes so Crashlytics traces are fully symbolicated (mapping.txt auto-upload verified — `uploadCrashlyticsMappingFileRelease` runs with these settings).
  - `Signature,InnerClasses,EnclosingMethod` for generic reflection (Gson TypeToken, FastAdapter TypeUtils).

## Verified
- `./gradlew assembleRelease` passes; R8 reports no missing-class warnings.
- EventBus, Retrofit, Gson, RxJava2, Room, Glide, and Firebase libs all bundle their own consumer rules — no manual rules needed (verified in their AARs/jars).
- No `getIdentifier`/reflection usage in app code, so resource shrinking is safe.

## Testing
- [ ] Smoke-test the release APK: translations list (Gson), reciters list (Firestore), navigation drawer, per-aya audio.
- [ ] Confirm mapping.txt appears in the Crashlytics console for the next release.