### PR TITLE
Fix release workflow tag handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Tag and push
         run: |
           next="${{ steps.version.outputs.next }}"
-          git tag "$next"
+          git tag -a "$next" -m "Release $next"
           git push origin "$next"
 
       - name: Create GitHub release
@@ -77,7 +77,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NEXT: ${{ steps.version.outputs.next }}
         run: |
-          prev=$(git describe --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' 'HEAD~1')
+          prev=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' 'HEAD~1')
           {
             git log "$prev".."${{ github.sha }}" --pretty=format:'- %s (%h)'
             echo


### PR DESCRIPTION
The release workflow failed at the 'Create GitHub release' step with `fatal: No annotated tags can describe '...'` because `git describe` only considers annotated tags, while the workflow created lightweight tags.

- Create release tags as annotated (`git tag -a`)
- Add `--tags` to `git describe` so lightweight tags already on the repo are still considered