### PR TITLE
Migrate downloads manager, reciter dialogs and translations screens to MVVM (#258, #259, #260)

### DIFF
--- a/app/src/main/java/app/quranhub/data/Constants.kt
+++ b/app/src/main/java/app/quranhub/data/Constants.kt
@@ -94,5 +94,12 @@ object Constants {
         /* It's important that the index of any recitation name is the same as the ID integer given for it above */
         @JvmField
         val NAMES_STR_IDS = intArrayOf(R.string.hafs_recitation, R.string.warsh_recitation)
+
+        /** Maps a recitation ID to its Firestore document key. */
+        fun keyForRecitation(recitationId: Int): String = when (recitationId) {
+            HAFS_ID -> HAFS_KEY
+            WARSH_ID -> WARSH_KEY
+            else -> error("Invalid recitation id: $recitationId")
+        }
     }
 }

--- a/app/src/main/java/app/quranhub/data/local/dao/TranslationBookDao.kt
+++ b/app/src/main/java/app/quranhub/data/local/dao/TranslationBookDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import app.quranhub.data.local.entity.TranslationBook
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface TranslationBookDao {
@@ -17,7 +18,7 @@ interface TranslationBookDao {
     fun getAllByIds(vararg ids: Int): LiveData<List<TranslationBook?>?>?
 
     @Query("SELECT * FROM TranslationBook WHERE language=:langCode")
-    fun getByLanguage(langCode: String?): LiveData<List<TranslationBook?>?>?
+    fun getByLanguage(langCode: String?): Flow<List<TranslationBook>>
 
     @Query("SELECT * FROM TranslationBook WHERE id=:id")
     suspend fun findById(id: String?): TranslationBook?

--- a/app/src/main/java/app/quranhub/data/remote/TranslationDownloader.kt
+++ b/app/src/main/java/app/quranhub/data/remote/TranslationDownloader.kt
@@ -11,8 +11,11 @@ import com.downloader.PRDownloader
 import com.downloader.Progress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TranslationDownloader(
     val translationBook: TranslationBook,
@@ -51,10 +54,14 @@ class TranslationDownloader(
             }
             .setOnCancelListener {
                 Log.d(TAG, "onCancel: downloadId = $downloadId")
+                // NonCancellable: the cleanup delete must run even when this
+                // downloader's scope is cancelled with it
                 scope.launch {
-                    UserDatabase.getInstance(appContext).translationBookDao.delete(
-                        translationBook
-                    )
+                    withContext(NonCancellable) {
+                        UserDatabase.getInstance(appContext).translationBookDao.delete(
+                            translationBook
+                        )
+                    }
                 }
                 callback?.onDownloadCancelled()
             }
@@ -95,17 +102,24 @@ class TranslationDownloader(
                 override fun onError(error: Error) {
                     Log.e(TAG, "PRDownloader: downloadId = $downloadId ->  error")
                     scope.launch {
-                        UserDatabase.getInstance(appContext).translationBookDao.delete(
-                            translationBook
-                        )
+                        withContext(NonCancellable) {
+                            UserDatabase.getInstance(appContext).translationBookDao.delete(
+                                translationBook
+                            )
+                        }
                     }
                     callback?.onDownloadFailed()
                 }
             })
     }
 
+    /**
+     * Cancels the PRDownloader request and this downloader's coroutine scope.
+     * The cleanup DB deletes (cancel/error) still run via [NonCancellable].
+     */
     fun cancel() {
         PRDownloader.cancel(downloadId)
+        scope.cancel()
     }
 
     private fun updateProgressPercentage(downloadLevelPercentage: Int) {

--- a/app/src/main/java/app/quranhub/data/remote/TranslationDownloader.kt
+++ b/app/src/main/java/app/quranhub/data/remote/TranslationDownloader.kt
@@ -9,6 +9,10 @@ import com.downloader.Error
 import com.downloader.OnDownloadListener
 import com.downloader.PRDownloader
 import com.downloader.Progress
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 class TranslationDownloader(
     val translationBook: TranslationBook,
@@ -18,6 +22,10 @@ class TranslationDownloader(
     private val appContext: Context
 
     private var downloadId = 0
+
+    // IO scope for the download bookkeeping DB writes (structured coroutines
+    // replacing the former raw Threads)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     init {
         this.appContext = appContext.applicationContext
@@ -31,12 +39,10 @@ class TranslationDownloader(
 
         // Make sure we have a path to the file
         dbPath.parentFile.mkdirs()
-        object : Thread() {
-            override fun run() {
-                translationBook.downloadStatus = NetworkUtil.STATUS_DOWNLOADING
-                UserDatabase.getInstance(appContext).translationBookDao.insert(translationBook)
-            }
-        }.start()
+        scope.launch {
+            translationBook.downloadStatus = NetworkUtil.STATUS_DOWNLOADING
+            UserDatabase.getInstance(appContext).translationBookDao.insert(translationBook)
+        }
         downloadId = PRDownloader.download(downloadUrl, dbPath.parent, dbPath.name)
             .build()
             .setOnStartOrResumeListener {
@@ -45,13 +51,11 @@ class TranslationDownloader(
             }
             .setOnCancelListener {
                 Log.d(TAG, "onCancel: downloadId = $downloadId")
-                object : Thread() {
-                    override fun run() {
-                        UserDatabase.getInstance(appContext).translationBookDao.delete(
-                            translationBook
-                        )
-                    }
-                }.start()
+                scope.launch {
+                    UserDatabase.getInstance(appContext).translationBookDao.delete(
+                        translationBook
+                    )
+                }
                 callback?.onDownloadCancelled()
             }
             .setOnProgressListener { progress: Progress ->
@@ -79,26 +83,22 @@ class TranslationDownloader(
             .start(object : OnDownloadListener {
                 override fun onDownloadComplete() {
                     Log.d(TAG, "PRDownloader: downloadId = $downloadId ->  completed")
-                    object : Thread() {
-                        override fun run() {
-                            translationBook.downloadStatus = NetworkUtil.STATUS_DOWNLOADED
-                            UserDatabase.getInstance(appContext).translationBookDao.insert(
-                                translationBook
-                            )
-                        }
-                    }.start()
+                    scope.launch {
+                        translationBook.downloadStatus = NetworkUtil.STATUS_DOWNLOADED
+                        UserDatabase.getInstance(appContext).translationBookDao.insert(
+                            translationBook
+                        )
+                    }
                     callback?.onDownloadFinished()
                 }
 
                 override fun onError(error: Error) {
                     Log.e(TAG, "PRDownloader: downloadId = $downloadId ->  error")
-                    object : Thread() {
-                        override fun run() {
-                            UserDatabase.getInstance(appContext).translationBookDao.delete(
-                                translationBook
-                            )
-                        }
-                    }.start()
+                    scope.launch {
+                        UserDatabase.getInstance(appContext).translationBookDao.delete(
+                            translationBook
+                        )
+                    }
                     callback?.onDownloadFailed()
                 }
             })
@@ -109,12 +109,10 @@ class TranslationDownloader(
     }
 
     private fun updateProgressPercentage(downloadLevelPercentage: Int) {
-        object : Thread() {
-            override fun run() {
-                translationBook.downloadLevelPercentage = downloadLevelPercentage
-                UserDatabase.getInstance(appContext).translationBookDao.insert(translationBook)
-            }
-        }.start()
+        scope.launch {
+            translationBook.downloadLevelPercentage = downloadLevelPercentage
+            UserDatabase.getInstance(appContext).translationBookDao.insert(translationBook)
+        }
     }
 
     interface TranslationDownloadCallback {

--- a/app/src/main/java/app/quranhub/data/repository/RecitationsRepository.kt
+++ b/app/src/main/java/app/quranhub/data/repository/RecitationsRepository.kt
@@ -4,34 +4,32 @@ import app.quranhub.data.model.ReciterModel
 import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
-import io.reactivex.Single
-import io.reactivex.SingleEmitter
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class RecitationsRepository {
 
     private val db = FirebaseFirestore.getInstance()
 
-    fun getRecitersForRecitation(recitationKey: String): Single<List<ReciterModel>?> {
-
-        return Single.create { emitter: SingleEmitter<List<ReciterModel>?> ->
+    suspend fun getRecitersForRecitation(recitationKey: String): List<ReciterModel> {
+        return suspendCancellableCoroutine { continuation ->
             db.collection("recitations")
                 .document(recitationKey)
                 .collection("reciters")
                 .get()
                 .addOnCompleteListener { task: Task<QuerySnapshot> ->
                     if (task.isSuccessful) {
-                        val reciterModels = task.result.toObjects(
-                            ReciterModel::class.java
+                        continuation.resume(
+                            task.result.toObjects(ReciterModel::class.java)
                         )
-                        emitter.onSuccess(reciterModels)
                     } else {
-                        emitter.onError(task.exception!!)
+                        continuation.resumeWithException(
+                            task.exception
+                                ?: IllegalStateException("Firestore task failed without exception")
+                        )
                     }
                 }
         }
-    }
-
-    companion object {
-        private val TAG = RecitationsRepository::class.java.simpleName
     }
 }

--- a/app/src/main/java/app/quranhub/data/service/DownloadFinishedHolder.kt
+++ b/app/src/main/java/app/quranhub/data/service/DownloadFinishedHolder.kt
@@ -1,0 +1,31 @@
+package app.quranhub.data.service
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Typed flow holder for download-finished notifications — the single source
+ * of truth between the downloader services and their UI consumers, replacing
+ * the former greenrobot `DownloadFinishEvent` EventBus stream.
+ *
+ * Carries no replay: consumers only observe completions that happen while
+ * they are started, like the fire-and-forget EventBus contract this replaces.
+ *
+ * [notifyFinished] is written only from the services' main thread; consumers
+ * collect on their own lifecycle scopes.
+ */
+object DownloadFinishedHolder {
+
+    private val _finished = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+    )
+
+    /** Emits once whenever a downloader service finishes all its downloads. */
+    val finished: SharedFlow<Unit> = _finished
+
+    fun notifyFinished() {
+        _finished.tryEmit(Unit)
+    }
+}

--- a/app/src/main/java/app/quranhub/data/service/QuranAudioDownloaderService.kt
+++ b/app/src/main/java/app/quranhub/data/service/QuranAudioDownloaderService.kt
@@ -2,10 +2,8 @@ package app.quranhub.data.service
 
 import android.content.Context
 import android.content.Intent
-import android.os.AsyncTask
 import android.os.Bundle
 import android.util.Log
-import android.util.Pair
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import app.quranhub.R
@@ -13,7 +11,6 @@ import app.quranhub.data.Constants
 import app.quranhub.data.local.db.MushafDatabase
 import app.quranhub.data.local.db.UserDatabase
 import app.quranhub.data.local.entity.QuranAudio
-import app.quranhub.data.service.QuranAudioDownloaderService.DownloadFinishEvent
 import app.quranhub.prdownloader_service.DownloadRequestInfo
 import app.quranhub.prdownloader_service.PRDownloaderService
 import app.quranhub.util.LocaleUtils
@@ -21,7 +18,11 @@ import app.quranhub.util.QuranAudioDownloadUtils
 import app.quranhub.util.QuranAudioFileUtils
 import com.downloader.Error
 import com.downloader.Progress
-import org.greenrobot.eventbus.EventBus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * `PRDownloaderService` for Quran audio files.
@@ -33,7 +34,7 @@ import org.greenrobot.eventbus.EventBus
  *
  *
  *
- * You can subscribe to [DownloadFinishEvent] with `EventBus` to get notified when all
+ * You can collect [DownloadFinishedHolder.finished] to get notified when all
  * the downloads finish, either successfully or unsuccessfully, and this service stops.
  *
  *
@@ -117,29 +118,27 @@ class QuranAudioDownloaderService : PRDownloaderService() {
 
     override fun onDownloadComplete(downloadRequestInfo: DownloadRequestInfo) {
         Log.d(TAG, "onDownloadComplete :: downloadRequestInfo=$downloadRequestInfo")
-        object : Thread() {
-            override fun run() {
-                val recitationId = downloadRequestInfo.extraInfo!!.getInt(
-                    DRI_EXTRA_INFO_RECITATION_ID
-                )
-                val reciterId = downloadRequestInfo.extraInfo!!.getString(
-                    DRI_EXTRA_INFO_RECITER_ID
-                )
-                val ayaId = downloadRequestInfo.extraInfo!!.getInt(DRI_EXTRA_INFO_AYA_ID)
-                val mushafDatabase = MushafDatabase.getInstance(this@QuranAudioDownloaderService)
-                val userDatabase = UserDatabase.getInstance(this@QuranAudioDownloaderService)
-                val aya = mushafDatabase.ayaDao.findAyaById(ayaId)
-                val filePath = (QuranAudioFileUtils.getLocalRelativeDirPath(recitationId, reciterId)
-                        + downloadRequestInfo.fileName)
-                val sheikhRecitationId = userDatabase.reciterRecitationDao
-                    .getSheikhRecitationId(recitationId, reciterId)
-                val quranAudio = QuranAudio(
-                    page = aya!!.page, sura = aya.sura, aya = aya.suraAya,
-                    ayaId = ayaId, filePath = filePath, sheikhRecitationId = sheikhRecitationId
-                )
-                userDatabase.quranAudioDao.insert(quranAudio)
-            }
-        }.start()
+        serviceScope.launch {
+            val recitationId = downloadRequestInfo.extraInfo!!.getInt(
+                DRI_EXTRA_INFO_RECITATION_ID
+            )
+            val reciterId = downloadRequestInfo.extraInfo!!.getString(
+                DRI_EXTRA_INFO_RECITER_ID
+            )
+            val ayaId = downloadRequestInfo.extraInfo!!.getInt(DRI_EXTRA_INFO_AYA_ID)
+            val mushafDatabase = MushafDatabase.getInstance(this@QuranAudioDownloaderService)
+            val userDatabase = UserDatabase.getInstance(this@QuranAudioDownloaderService)
+            val aya = mushafDatabase.ayaDao.findAyaById(ayaId)
+            val filePath = (QuranAudioFileUtils.getLocalRelativeDirPath(recitationId, reciterId)
+                    + downloadRequestInfo.fileName)
+            val sheikhRecitationId = userDatabase.reciterRecitationDao
+                .getSheikhRecitationId(recitationId, reciterId)
+            val quranAudio = QuranAudio(
+                page = aya!!.page, sura = aya.sura, aya = aya.suraAya,
+                ayaId = ayaId, filePath = filePath, sheikhRecitationId = sheikhRecitationId
+            )
+            userDatabase.quranAudioDao.insert(quranAudio)
+        }
     }
 
     override fun onDownloadError(downloadRequestInfo: DownloadRequestInfo, error: Error) {
@@ -153,14 +152,10 @@ class QuranAudioDownloaderService : PRDownloaderService() {
         Log.d(TAG, "onStop")
 
 //        Toast.makeText(this, R.string.toast_download_quran_audio_finished, Toast.LENGTH_SHORT).show();
-        EventBus.getDefault().post(DownloadFinishEvent())
+        DownloadFinishedHolder.notifyFinished()
     }
 
-    /**
-     * `EventBus` event that gets posted when all the downloads finish, either successfully or
-     * unsuccessfully, and [QuranAudioDownloaderService] stops.
-     */
-    class DownloadFinishEvent
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     companion object {
         private val TAG = QuranAudioDownloaderService::class.java.simpleName
         private const val EXTRA_START_AYA_ID = "EXTRA_START_AYA_ID"
@@ -176,24 +171,20 @@ class QuranAudioDownloaderService : PRDownloaderService() {
             context: Context, recitationId: Int, reciterId: String?,
             suraId: Int
         ) {
-            object : AsyncTask<Void?, Void?, Pair<Int?, Int?>?>() {
-                override fun doInBackground(vararg params: Void?): Pair<Int?, Int?> {
-                    val ayaDao = MushafDatabase.getInstance(context).ayaDao
-                    val startAyaId = ayaDao.getFirstAyaInSura(suraId)?.id
-                    val endAyaId = ayaDao.getLastAyaInSura(suraId)?.id
-                    return Pair(startAyaId, endAyaId)
-                }
-
-                override fun onPostExecute(ayaIdPair: Pair<Int?, Int?>?) {
+            CoroutineScope(Dispatchers.IO).launch {
+                val ayaDao = MushafDatabase.getInstance(context).ayaDao
+                val startAyaId = ayaDao.getFirstAyaInSura(suraId)?.id
+                val endAyaId = ayaDao.getLastAyaInSura(suraId)?.id
+                withContext(Dispatchers.Main) {
                     downloadAyaRange(
                         context,
                         recitationId,
                         reciterId,
-                        ayaIdPair!!.first!!,
-                        ayaIdPair.second!!
+                        startAyaId!!,
+                        endAyaId!!
                     )
                 }
-            }.execute()
+            }
         }
 
         @JvmStatic

--- a/app/src/main/java/app/quranhub/data/service/QuranAudioDownloaderService.kt
+++ b/app/src/main/java/app/quranhub/data/service/QuranAudioDownloaderService.kt
@@ -21,6 +21,7 @@ import com.downloader.Progress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -154,8 +155,13 @@ class QuranAudioDownloaderService : PRDownloaderService() {
 //        Toast.makeText(this, R.string.toast_download_quran_audio_finished, Toast.LENGTH_SHORT).show();
         DownloadFinishedHolder.notifyFinished()
     }
-
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
     companion object {
         private val TAG = QuranAudioDownloaderService::class.java.simpleName
         private const val EXTRA_START_AYA_ID = "EXTRA_START_AYA_ID"
@@ -166,12 +172,15 @@ class QuranAudioDownloaderService : PRDownloaderService() {
         private const val DRI_EXTRA_INFO_RECITATION_ID = "DRI_EXTRA_INFO_RECITATION_ID"
         private const val DRI_EXTRA_INFO_RECITER_ID = "DRI_EXTRA_INFO_RECITER_ID"
 
+        // IO scope for resolving the aya range before the service starts
+        private val helperScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
         @JvmStatic
         fun downloadSura(
             context: Context, recitationId: Int, reciterId: String?,
             suraId: Int
         ) {
-            CoroutineScope(Dispatchers.IO).launch {
+            helperScope.launch {
                 val ayaDao = MushafDatabase.getInstance(context).ayaDao
                 val startAyaId = ayaDao.getFirstAyaInSura(suraId)?.id
                 val endAyaId = ayaDao.getLastAyaInSura(suraId)?.id

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/BaseDownloadsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/BaseDownloadsFragment.kt
@@ -1,25 +1,24 @@
 package app.quranhub.ui.downloads_manager
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.os.AsyncTask
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import app.quranhub.data.service.QuranAudioDownloaderService.DownloadFinishEvent
+import app.quranhub.data.service.DownloadFinishedHolder
 import app.quranhub.databinding.FragmentDownloadsBinding
 import app.quranhub.ui.downloads_manager.BaseDownloadsFragment.DownloadsManagerNavigationCallbacks
 import app.quranhub.ui.downloads_manager.adapters.DownloadsAdapter
 import app.quranhub.ui.downloads_manager.model.DisplayableDownload
-import app.quranhub.util.FragmentUtils.isSafeFragment
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
+import app.quranhub.ui.downloads_manager.viewmodel.BaseDownloadsViewModel
+import kotlinx.coroutines.launch
 
 /**
  * Base for downloads screen fragments.
@@ -35,10 +34,11 @@ import org.greenrobot.eventbus.ThreadMode
  */
 abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.ItemClickListener {
 
+    /** The screen's ViewModel, providing the [DisplayableDownload] listing state. */
+    protected abstract val viewModel: BaseDownloadsViewModel
+
     private var binding: FragmentDownloadsBinding? = null
 
-    protected var displayableDownloads: List<DisplayableDownload>? = null
-        private set
     protected var downloadsAdapter: DownloadsAdapter? = null
         private set
     private var description: String? = null
@@ -83,7 +83,7 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
         }
         setupDescription()
         setupDownloadsRecyclerView()
-        displayDownloadItems()
+        observeViewModel()
     }
 
     private fun setupDescription() {
@@ -105,66 +105,38 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
             layoutManager.orientation
         )
         binding!!.rvDownloads.addItemDecoration(dividerItemDecoration)
-        displayableDownloads = mutableListOf()
-        downloadsAdapter = DownloadsAdapter(displayableDownloads!!, this, editable)
+        downloadsAdapter = DownloadsAdapter(emptyList<DisplayableDownload>(), this, editable)
         binding!!.rvDownloads.adapter = downloadsAdapter
     }
 
-    @SuppressLint("StaticFieldLeak")
-    private fun displayDownloadItems() {
-        object : AsyncTask<Void?, Void?, List<DisplayableDownload>>() {
-
-            override fun onPreExecute() {
-                binding!!.progressBar.visibility = View.VISIBLE
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.uiState.collect { state ->
+                        binding!!.progressBar.visibility =
+                            if (state.loading) View.VISIBLE else View.GONE
+                        if (!state.loading) {
+                            Log.d(TAG, "Provided displayableDownloads=${state.downloads}")
+                            downloadsAdapter!!.setDisplayableDownloads(state.downloads)
+                        }
+                    }
+                }
+                launch {
+                    // refresh whenever a downloader service finishes its downloads
+                    DownloadFinishedHolder.finished.collect { viewModel.refresh() }
+                }
             }
-
-            override fun doInBackground(vararg voids: Void?): List<DisplayableDownload> {
-                if (!isSafeFragment(this@BaseDownloadsFragment)) return emptyList()
-
-                return provideDisplayableDownloads()
-            }
-
-            override fun onPostExecute(downloads: List<DisplayableDownload>) {
-                if (!isSafeFragment(this@BaseDownloadsFragment)) return
-
-                Log.d(TAG, "Provided displayableDownloads=$downloads")
-                displayableDownloads = downloads
-                downloadsAdapter!!.setDisplayableDownloads(displayableDownloads!!)
-                binding!!.progressBar.visibility = View.GONE
-            }
-        }.execute()
-    }
-
-    protected fun refresh() {
-        displayDownloadItems()
+        }
     }
 
     fun getEditable(): Boolean {
         return editable
     }
 
-    /**
-     * This method will be called from a background thread. You don't have to create a new one.
-     */
-    protected abstract fun provideDisplayableDownloads(): List<DisplayableDownload>
-    override fun onStart() {
-        super.onStart()
-        EventBus.getDefault().register(this)
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_EDITABLE, editable)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        EventBus.getDefault().unregister(this)
-    }
-
-    @Subscribe(threadMode = ThreadMode.MAIN)
-    fun onDownloadFinishEvent(event: DownloadFinishEvent?) {
-        refresh()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsManagerActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsManagerActivity.kt
@@ -26,6 +26,11 @@ class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallb
 
     private var selectedTabIndex = 0
 
+    // True while restoring the selected tab after recreation, so the tab
+    // listener doesn't recreate the screen: FragmentManager already restored
+    // the fragment back stack (e.g. the suras list the user was viewing).
+    private var isRestoringTabSelection = false
+
     private lateinit var binding: ActivityDownloadsManagerBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,6 +46,7 @@ class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallb
 
             override fun onTabSelected(tab: TabLayout.Tab?) {
                 selectedTabIndex = tab?.position ?: 0
+                if (isRestoringTabSelection) return
                 when (tab?.position) {
                     0 -> showQuranImagesDownloadsTab()
                     1 -> showAudioDownloadsTab()
@@ -55,11 +61,17 @@ class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallb
             // restore saved instance state, if any,
             editable = savedInstanceState.getBoolean(STATE_EDITABLE)
             selectedTabIndex = savedInstanceState.getInt(STATE_SELECTED_TAB_INDEX, 0)
+            hasMenu = savedInstanceState.getBoolean(STATE_HAS_MENU)
+
+            // FragmentManager restores the fragment back stack automatically
+            // (the exact screen the user was viewing, incl. the suras list);
+            // only re-select the tab visually, without recreating the screen.
+            isRestoringTabSelection = true
+            binding.tabLayout.getTabAt(selectedTabIndex)?.select()
+            isRestoringTabSelection = false
         } else {
             showQuranImagesDownloadsTab()
         }
-
-        binding.tabLayout.getTabAt(selectedTabIndex)?.select()
 
         /* sync the activity's action bar with the BaseDownloadsFragment 'editable' state
            when user's back navigating */
@@ -105,6 +117,7 @@ class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallb
         super.onSaveInstanceState(outState)
         outState.putBoolean(STATE_EDITABLE, editable)
         outState.putInt(STATE_SELECTED_TAB_INDEX, selectedTabIndex)
+        outState.putBoolean(STATE_HAS_MENU, hasMenu)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -210,5 +223,6 @@ class DownloadsManagerActivity : BaseActivity(), DownloadsManagerNavigationCallb
 
         private const val STATE_EDITABLE = "STATE_EDITABLE"
         private const val STATE_SELECTED_TAB_INDEX = "STATE_SELECTED_TAB_INDEX"
+        private const val STATE_HAS_MENU = "STATE_HAS_MENU"
     }
 }

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsRecitationsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsRecitationsFragment.kt
@@ -2,40 +2,23 @@ package app.quranhub.ui.downloads_manager
 
 import android.content.Context
 import android.os.Bundle
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import app.quranhub.R
-import app.quranhub.data.Constants
-import app.quranhub.data.local.db.UserDatabase
 import app.quranhub.ui.downloads_manager.dialogs.DeleteConfirmationDialogFragment.Companion.newInstance
 import app.quranhub.ui.downloads_manager.dialogs.DeleteConfirmationDialogFragment.DeleteConfirmationCallbacks
 import app.quranhub.ui.downloads_manager.model.DisplayableDownload
-import app.quranhub.util.FragmentUtils
-import app.quranhub.util.QuranAudioDeleteUtils.DeleteFinishListener
-import app.quranhub.util.QuranAudioDeleteUtils.deleteRecitationAudio
+import app.quranhub.ui.downloads_manager.viewmodel.DownloadsRecitationsViewModel
 
 class DownloadsRecitationsFragment : BaseDownloadsFragment(), DeleteConfirmationCallbacks {
 
-    override fun provideDisplayableDownloads(): List<DisplayableDownload> {
-
-        if (!FragmentUtils.isSafeFragment(this)) return emptyList()
-
-        val downloads: MutableList<DisplayableDownload> = ArrayList()
-
-        for (recitationStringResId in Constants.Recitation.NAMES_STR_IDS) {
-            downloads.add(DisplayableDownload(getString(recitationStringResId)))
+    override val viewModel: DownloadsRecitationsViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                DownloadsRecitationsViewModel(requireActivity().application)
+            }
         }
-
-        // check if recitations are downloadable and/or deletable & the number of downloaded reciters each.
-        for (i in downloads.indices) {
-            val displayableDownload = downloads[i]
-            val numOfDownloadedReciters = UserDatabase.getInstance(requireContext())
-                .reciterRecitationDao
-                .getNumOfRecitersWithDownloads(i)
-            displayableDownload.downloadedAmount =
-                getString(R.string.downloaded_reciters_num, numOfDownloadedReciters)
-            displayableDownload.isDeletable = numOfDownloadedReciters > 0
-            displayableDownload.isDownloadable = true // TODO check if it's not downloadable
-        }
-        return downloads
     }
 
     override fun onClickItem(displayableDownload: DisplayableDownload?, position: Int) {
@@ -51,14 +34,7 @@ class DownloadsRecitationsFragment : BaseDownloadsFragment(), DeleteConfirmation
     }
 
     override fun onConfirmDelete(deletePosition: Int) {
-        deleteRecitationAudio(
-            requireContext(),
-            deletePosition,
-            object : DeleteFinishListener {
-                override fun onDeleteFinish() {
-                    refresh()
-                }
-            })
+        viewModel.deleteRecitation(deletePosition)
     }
 
     override fun onDownloadItem(displayableDownload: DisplayableDownload?, position: Int) {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsRecitersFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsRecitersFragment.kt
@@ -1,29 +1,33 @@
 package app.quranhub.ui.downloads_manager
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.os.AsyncTask
 import android.os.Bundle
-import android.util.Log
+import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import app.quranhub.R
-import app.quranhub.data.Constants
-import app.quranhub.data.local.db.UserDatabase
-import app.quranhub.data.local.entity.Reciter
-import app.quranhub.data.local.entity.ReciterRecitation
-import app.quranhub.data.repository.RecitationsRepository
 import app.quranhub.ui.downloads_manager.dialogs.DeleteConfirmationDialogFragment.Companion.newInstance
 import app.quranhub.ui.downloads_manager.dialogs.DeleteConfirmationDialogFragment.DeleteConfirmationCallbacks
 import app.quranhub.ui.downloads_manager.model.DisplayableDownload
-import app.quranhub.util.QuranAudioDeleteUtils.DeleteFinishListener
-import app.quranhub.util.QuranAudioDeleteUtils.deleteReciterAudio
+import app.quranhub.ui.downloads_manager.viewmodel.BaseDownloadsViewModel
+import app.quranhub.ui.downloads_manager.viewmodel.DownloadsRecitersViewModel
+import kotlinx.coroutines.launch
 
 class DownloadsRecitersFragment : BaseDownloadsFragment(), DeleteConfirmationCallbacks {
 
     private var recitationId = 0
 
-    private var reciters: List<Reciter>? = null
-
-    private val recitationsRepository = RecitationsRepository()
+    override val viewModel: DownloadsRecitersViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                DownloadsRecitersViewModel(requireActivity().application, recitationId)
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,60 +36,29 @@ class DownloadsRecitersFragment : BaseDownloadsFragment(), DeleteConfirmationCal
         }
     }
 
-    override fun provideDisplayableDownloads(): List<DisplayableDownload> {
-        val displayableDownloadsList: MutableList<DisplayableDownload> = mutableListOf()
-
-        val recitationKey: String = when (recitationId) {
-            Constants.Recitation.HAFS_ID -> Constants.Recitation.HAFS_KEY
-            Constants.Recitation.WARSH_ID -> Constants.Recitation.WARSH_KEY
-            else -> error("Invalid recitation id: $recitationId")
-        }
-
-        reciters = try {
-            val reciterModels =
-                recitationsRepository.getRecitersForRecitation(recitationKey).blockingGet()
-            if (reciters != null) {
-                reciterModels!!.map {
-                    Reciter(
-                        it.id,
-                        it.getLocalizedName(requireContext()),
-                        it.getLocalizedNationality(requireContext()),
-                        it.audioBaseUrl
-                    )
-                }
-            } else {
-                Log.e(TAG, "reciterModels is null!")
-                retrieveLocalReciters()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to retrieve reciters from RecitationsRepository.")
-            retrieveLocalReciters()
-        }
-
-        // process reciters list
-        for (r in reciters!!) {
-            val userDatabase = UserDatabase.getInstance(requireContext())
-            val displayableDownload = DisplayableDownload(
-                r.name
-            )
-            val downloadedSurasIds = userDatabase.reciterRecitationDao
-                .getSurasIdsForReciterInRecitation(recitationId, r.id)
-            displayableDownload.downloadedAmount =
-                getString(R.string.downloaded_amount_suras, downloadedSurasIds.size)
-            displayableDownload.isDownloadable = downloadedSurasIds.size < 114
-            displayableDownload.isDeletable = downloadedSurasIds.isNotEmpty()
-            displayableDownloadsList.add(displayableDownload)
-        }
-        return displayableDownloadsList
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeEvents()
     }
 
-    private fun retrieveLocalReciters(): List<Reciter> {
-        return UserDatabase.getInstance(requireContext())
-            .reciterDao.getAllForRecitation(recitationId)
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.events.collect { event ->
+                    when (event) {
+                        is BaseDownloadsViewModel.DownloadsEvent.OpenAudioDownloadAmountDialog ->
+                            navigationCallbacks!!.openAudioDownloadAmountDialog(
+                                event.recitationId, event.reciterId
+                            )
+                        is BaseDownloadsViewModel.DownloadsEvent.DownloadStarted -> {}
+                    }
+                }
+            }
+        }
     }
 
     override fun onClickItem(displayableDownload: DisplayableDownload?, position: Int) {
-        val reciter = reciters!![position]
+        val reciter = viewModel.reciterAt(position)
         navigationCallbacks!!.gotoDownloadsSuras(recitationId, reciter.id, reciter.name)
     }
 
@@ -98,37 +71,11 @@ class DownloadsRecitersFragment : BaseDownloadsFragment(), DeleteConfirmationCal
     }
 
     override fun onConfirmDelete(deletePosition: Int) {
-        deleteReciterAudio(requireContext(),
-            recitationId,
-            reciters!![deletePosition].id,
-            object : DeleteFinishListener {
-                override fun onDeleteFinish() {
-                    refresh()
-                }
-            })
+        viewModel.deleteReciter(deletePosition)
     }
 
-    @SuppressLint("StaticFieldLeak")
     override fun onDownloadItem(displayableDownload: DisplayableDownload?, position: Int) {
-        val reciter = reciters!![position]
-        object : AsyncTask<Void?, Void?, Void?>() {
-            override fun doInBackground(vararg voids: Void?): Void? {
-                val userDatabase = UserDatabase.getInstance(requireContext())
-                if (userDatabase.reciterDao.getById(reciter.id) == null) {
-                    userDatabase.reciterDao.insert(reciter)
-                }
-                if (userDatabase.reciterRecitationDao[recitationId, reciter.id] == null) {
-                    userDatabase.reciterRecitationDao.insert(
-                        ReciterRecitation(recitationId = recitationId, reciterId = reciter.id)
-                    )
-                }
-                return null
-            }
-
-            override fun onPostExecute(aVoid: Void?) {
-                navigationCallbacks!!.openAudioDownloadAmountDialog(recitationId, reciter.id)
-            }
-        }.execute()
+        viewModel.onDownloadItem(position)
     }
 
     companion object {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsSurasFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsSurasFragment.kt
@@ -1,26 +1,38 @@
 package app.quranhub.ui.downloads_manager
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.os.AsyncTask
 import android.os.Bundle
+import android.view.View
 import android.widget.Toast
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import app.quranhub.R
-import app.quranhub.data.local.db.UserDatabase
-import app.quranhub.data.local.entity.ReciterRecitation
-import app.quranhub.data.local.prefs.AppPreferencesManager
-import app.quranhub.data.service.QuranAudioDownloaderService.Companion.downloadSura
 import app.quranhub.ui.downloads_manager.dialogs.DeleteConfirmationDialogFragment.Companion.newInstance
 import app.quranhub.ui.downloads_manager.dialogs.DeleteConfirmationDialogFragment.DeleteConfirmationCallbacks
 import app.quranhub.ui.downloads_manager.model.DisplayableDownload
-import app.quranhub.util.QuranAudioDeleteUtils.DeleteFinishListener
-import app.quranhub.util.QuranAudioDeleteUtils.deleteSuraAudio
+import app.quranhub.ui.downloads_manager.viewmodel.BaseDownloadsViewModel
+import app.quranhub.ui.downloads_manager.viewmodel.DownloadsSurasViewModel
+import kotlinx.coroutines.launch
 
 class DownloadsSurasFragment : BaseDownloadsFragment(), DeleteConfirmationCallbacks {
 
     private var recitationId = 0
     private var reciterId: String? = null
     private var reciterName: String? = null
+
+    override val viewModel: DownloadsSurasViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                DownloadsSurasViewModel(
+                    requireActivity().application, recitationId, reciterId!!
+                )
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,22 +43,26 @@ class DownloadsSurasFragment : BaseDownloadsFragment(), DeleteConfirmationCallba
         }
     }
 
-    override fun provideDisplayableDownloads(): List<DisplayableDownload> {
-        val displayableDownloadList: MutableList<DisplayableDownload> = ArrayList()
-        val suras = resources.getStringArray(R.array.sura_name)
-        for (i in suras.indices) {
-            val suraName = suras[i]
-            val displayableDownload = DisplayableDownload(suraName)
-            val suraId = i + 1
-            val isDownloadable = UserDatabase.getInstance(requireContext())
-                .quranAudioDao
-                .getForSura(recitationId, reciterId, suraId)
-                .isEmpty()
-            displayableDownload.isDownloadable = isDownloadable
-            displayableDownload.isDeletable = !isDownloadable
-            displayableDownloadList.add(displayableDownload)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeEvents()
+    }
+
+    private fun observeEvents() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.events.collect { event ->
+                    when (event) {
+                        is BaseDownloadsViewModel.DownloadsEvent.DownloadStarted ->
+                            Toast.makeText(
+                                requireContext(), R.string.msg_quran_audio_download_started,
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        is BaseDownloadsViewModel.DownloadsEvent.OpenAudioDownloadAmountDialog -> {}
+                    }
+                }
+            }
         }
-        return displayableDownloadList
     }
 
     override fun onClickItem(displayableDownload: DisplayableDownload?, position: Int) {}
@@ -60,54 +76,11 @@ class DownloadsSurasFragment : BaseDownloadsFragment(), DeleteConfirmationCallba
     }
 
     override fun onConfirmDelete(deletePosition: Int) {
-        val suraId = deletePosition + 1
-        deleteSuraAudio(
-            requireContext(),
-            recitationId,
-            reciterId!!,
-            suraId,
-            object : DeleteFinishListener {
-                override fun onDeleteFinish() {
-                    refresh()
-                }
-            })
+        viewModel.deleteSura(deletePosition)
     }
 
-    @SuppressLint("StaticFieldLeak")
     override fun onDownloadItem(displayableDownload: DisplayableDownload?, position: Int) {
-        val suraId = position + 1
-        object : AsyncTask<Void?, Void?, Void?>() {
-            override fun doInBackground(vararg voids: Void?): Void? {
-                val userDatabase = UserDatabase.getInstance(requireContext())
-                if (userDatabase.reciterDao.getById(reciterId) == null) {
-//                    userDatabase.getReciterDao()
-//                            .insert(new Reciter(reciterId, reciterName));
-                }
-                if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
-                    userDatabase.reciterRecitationDao
-                        .insert(
-                            ReciterRecitation(
-                                recitationId = recitationId,
-                                reciterId = reciterId!!
-                            )
-                        )
-                }
-                val recitationIdPreference =
-                    AppPreferencesManager.getRecitationSetting(requireContext())
-                if (recitationIdPreference == recitationId) {
-                    AppPreferencesManager.persistReciterSheikhSetting(requireContext(), reciterId)
-                }
-                return null
-            }
-
-            override fun onPostExecute(aVoid: Void?) {
-                downloadSura(requireContext(), recitationId, reciterId, suraId)
-                Toast.makeText(
-                    requireContext(), R.string.msg_quran_audio_download_started,
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }.execute()
+        viewModel.downloadSura(position)
     }
 
     companion object {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/AudioDownloadAmountDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/AudioDownloadAmountDialogFragment.kt
@@ -1,11 +1,9 @@
 package app.quranhub.ui.downloads_manager.dialogs
 
-import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.os.AsyncTask
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,16 +14,20 @@ import android.widget.ArrayAdapter
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import app.quranhub.R
-import app.quranhub.data.local.db.UserDatabase
-import app.quranhub.data.local.entity.ReciterRecitation
-import app.quranhub.data.service.QuranAudioDownloaderService.Companion.downloadQuran
-import app.quranhub.data.service.QuranAudioDownloaderService.Companion.downloadSura
 import app.quranhub.databinding.DialogAudioDownloadAmountBinding
+import app.quranhub.ui.downloads_manager.viewmodel.AudioDownloadAmountViewModel
 import app.quranhub.util.DialogUtils.DIALOG_STD_WIDTH_SCREEN_RATIO_LANDSCAPE
 import app.quranhub.util.DialogUtils.DIALOG_STD_WIDTH_SCREEN_RATIO_PORTRAIT
 import app.quranhub.util.DialogUtils.adjustDialogSize
 import app.quranhub.util.NetworkUtil.isNetworkAvailable
+import kotlinx.coroutines.launch
 
 /**
  * A `DialogFragment` that allows the user to choose the Quran audio amount he wants to download.
@@ -37,9 +39,18 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
     private var recitationId = 0
     private var reciterId: String? = null
     private var suraId = 0 // [optional, defaults to 1]
-    private var selectedOption = 0
     private var binding: DialogAudioDownloadAmountBinding? = null
     private var listener: AudioDownloadListener? = null
+
+    private val viewModel: AudioDownloadAmountViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                AudioDownloadAmountViewModel(
+                    requireActivity().application, recitationId, reciterId!!, suraId
+                )
+            }
+        }
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -82,8 +93,6 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
     }
 
     private fun initDialogView() {
-        setSelectedOption(OPTION_DOWNLOAD_SURA)
-
         // init surasSpinner
         val suras = resources.getStringArray(R.array.sura_name)
         val dataAdapter = ArrayAdapter(
@@ -92,7 +101,7 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
         )
         dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         binding!!.spinnerSuras.adapter = dataAdapter
-        binding!!.spinnerSuras.setSelection(suraId - 1)
+        binding!!.spinnerSuras.setSelection(viewModel.uiState.value.suraId - 1)
         binding!!.spinnerSuras.onItemSelectedListener =
             object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(
@@ -106,24 +115,13 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
                             resources.getColor(R.color.white_color)
                         )
                     }
-                    setSelectedOption(OPTION_DOWNLOAD_SURA)
-                    suraId = position + 1
+                    viewModel.onSuraSelected(position + 1)
                 }
 
                 override fun onNothingSelected(parent: AdapterView<*>?) {}
             }
         attachListeners()
-    }
-
-    private fun setSelectedOption(option: Int) {
-        selectedOption = option
-        if (selectedOption == OPTION_DOWNLOAD_SURA) {
-            binding!!.ivCheckOptionSuraDownload.visibility = View.VISIBLE
-            binding!!.ivCheckOptionDownloadAll.visibility = View.INVISIBLE
-        } else if (selectedOption == OPTION_DOWNLOAD_ALL) {
-            binding!!.ivCheckOptionSuraDownload.visibility = View.INVISIBLE
-            binding!!.ivCheckOptionDownloadAll.visibility = View.VISIBLE
-        }
+        observeViewModel()
     }
 
     override fun onResume() {
@@ -140,60 +138,56 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
     }
 
     private fun attachListeners() {
-        binding!!.clOptionSuraDownload.setOnClickListener { v: View? -> onSuraDownloadOptionClick() }
-        binding!!.clOptionDownloadAll.setOnClickListener { v: View? -> onDownloadAllOptionClick() }
+        binding!!.clOptionSuraDownload.setOnClickListener { v: View? ->
+            viewModel.onSuraDownloadOptionSelected()
+        }
+        binding!!.clOptionDownloadAll.setOnClickListener { v: View? ->
+            viewModel.onDownloadAllOptionSelected()
+        }
         binding!!.btnCancel.setOnClickListener { v: View? -> onCancelButtonClick() }
         binding!!.btnDownload.setOnClickListener { v: View? -> onDownloadButtonClick() }
     }
 
-    private fun onSuraDownloadOptionClick() {
-        setSelectedOption(OPTION_DOWNLOAD_SURA)
-    }
-
-    private fun onDownloadAllOptionClick() {
-        setSelectedOption(OPTION_DOWNLOAD_ALL)
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.uiState.collect { state ->
+                        binding?.ivCheckOptionSuraDownload?.visibility =
+                            if (state.selectedOption == OPTION_DOWNLOAD_SURA) View.VISIBLE else View.INVISIBLE
+                        binding?.ivCheckOptionDownloadAll?.visibility =
+                            if (state.selectedOption == OPTION_DOWNLOAD_ALL) View.VISIBLE else View.INVISIBLE
+                    }
+                }
+                launch {
+                    viewModel.events.collect { event ->
+                        when (event) {
+                            is AudioDownloadAmountViewModel.AudioDownloadAmountEvent.DownloadStarted -> {
+                                Toast.makeText(
+                                    requireContext(),
+                                    R.string.msg_quran_audio_download_started,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                                listener!!.onClickDownload()
+                                dismiss()
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun onCancelButtonClick() {
         dismiss()
     }
 
-    @SuppressLint("StaticFieldLeak")
     private fun onDownloadButtonClick() {
         if (!isNetworkAvailable(requireContext())) {
             Toast.makeText(activity, getString(R.string.no_internet), Toast.LENGTH_LONG).show()
             return
         }
-        object : AsyncTask<Void?, Void?, Void?>() {
-            override fun doInBackground(vararg voids: Void?): Void? {
-                // Store SheikhRecitation for the download recitation & reciter in DB
-                val userDatabase = UserDatabase.getInstance(requireContext())
-                if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
-                    userDatabase.reciterRecitationDao
-                        .insert(
-                            ReciterRecitation(
-                                recitationId = recitationId,
-                                reciterId = reciterId!!
-                            )
-                        )
-                }
-                return null
-            }
-
-            override fun onPostExecute(aVoid: Void?) {
-                if (selectedOption == OPTION_DOWNLOAD_SURA) {
-                    downloadSura(requireContext(), recitationId, reciterId, suraId)
-                } else if (selectedOption == OPTION_DOWNLOAD_ALL) {
-                    downloadQuran(requireContext(), recitationId, reciterId)
-                }
-                Toast.makeText(
-                    requireContext(), R.string.msg_quran_audio_download_started,
-                    Toast.LENGTH_SHORT
-                ).show()
-                listener!!.onClickDownload()
-                dismiss()
-            }
-        }.execute()
+        viewModel.startDownload()
     }
 
     interface AudioDownloadListener {
@@ -214,17 +208,9 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
          * Use this factory method to create a new instance of
          * this fragment using the provided parameters.
          *
-         * @param recitationId Recitation ID as in [Constants.Recitation]
+         * @param recitationId Recitation ID as in [app.quranhub.data.Constants.Recitation]
          * @param reciterId    A reciter ID.
          * @param suraId       A sura ID to be selected when opening the dialog.
-         * @return A new instance of fragment AudioDownloadAmountDialogFragment.
-         */
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param recitationId Recitation ID as in [Constants.Recitation]
-         * @param reciterId    A reciter ID.
          * @return A new instance of fragment AudioDownloadAmountDialogFragment.
          */
         @JvmOverloads

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/QuranRecitersDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/QuranRecitersDialogFragment.kt
@@ -1,38 +1,33 @@
 package app.quranhub.ui.downloads_manager.dialogs
 
-import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
-import android.os.AsyncTask
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import app.quranhub.R
-import app.quranhub.data.Constants
-import app.quranhub.data.local.db.UserDatabase
-import app.quranhub.data.local.entity.Reciter
-import app.quranhub.data.local.prefs.AppPreferencesManager
 import app.quranhub.data.model.ReciterModel
-import app.quranhub.data.repository.RecitationsRepository
 import app.quranhub.databinding.DialogQuranRecitersBinding
 import app.quranhub.ui.common.dialogs.OptionsListAdapter
 import app.quranhub.ui.downloads_manager.dialogs.QuranRecitersDialogFragment.ReciterSelectionListener
+import app.quranhub.ui.downloads_manager.viewmodel.ReciterPickerViewModel
 import app.quranhub.util.DialogUtils.adjustDialogSize
-import app.quranhub.util.FragmentUtils.isSafeFragment
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
-import io.reactivex.observers.DisposableSingleObserver
+import kotlinx.coroutines.launch
 
 /**
  * A `DialogFragment` that displays the available Quran reciters for the user to choose from.
@@ -47,13 +42,19 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
 
     private var recitationId = 0
     private var selectedReciterId: String? = null
-    private var selectedReciterIndex = -1
     private var binding: DialogQuranRecitersBinding? = null
     private var adapter: OptionsListAdapter? = null
     private var reciterSelectionListener: ReciterSelectionListener? = null
-    private val recitationsRepository = RecitationsRepository()
-    private var reciterModels: List<ReciterModel>? = null
-    private val compositeDisposable = CompositeDisposable()
+
+    private val viewModel: ReciterPickerViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                ReciterPickerViewModel(
+                    requireActivity().application, recitationId, selectedReciterId
+                )
+            }
+        }
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -96,38 +97,65 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
     private fun initDialogView() {
         binding!!.tvMsgDownloadedRecitersOnly.visibility = View.GONE
         binding!!.tvMsgInternetConnectionFailed.visibility = View.GONE
-        binding!!.progressBar.visibility = View.VISIBLE
         binding!!.btnSelect.isEnabled = false
-        attachListeners()
-    }
-
-    private fun attachListeners() {
         binding!!.btnSelect.setOnClickListener { onSelectClick() }
         binding!!.btnBack.setOnClickListener { onBackClick() }
+        observeViewModel()
     }
 
-    private fun setupRecitersRecyclerView() {
-        if (reciterModels != null) {
-            val recitersNames: MutableList<String> = ArrayList()
-            for (i in reciterModels!!.indices) {
-                val r = reciterModels!![i]
-                recitersNames.add(r.getLocalizedName(requireContext()))
-                if (r.id == selectedReciterId) {
-                    selectedReciterIndex = i
-                    binding!!.btnSelect.isEnabled = true
+    private fun observeViewModel() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.uiState.collect { state ->
+                        render(state)
+                    }
+                }
+                launch {
+                    viewModel.events.collect { event ->
+                        when (event) {
+                            is ReciterPickerViewModel.ReciterPickerEvent.NoReciters ->
+                                Toast.makeText(
+                                    requireContext(), R.string.no_reciters,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            is ReciterPickerViewModel.ReciterPickerEvent.ReciterSelected -> {
+                                reciterSelectionListener!!.onReciterSelected(
+                                    event.recitationId, event.reciterModel
+                                )
+                                dismiss()
+                            }
+                        }
+                    }
                 }
             }
-            binding!!.rvReciters.setHasFixedSize(true)
-            binding!!.rvReciters.layoutManager = LinearLayoutManager(
+        }
+    }
+
+    private fun render(state: ReciterPickerViewModel.ReciterPickerUiState) {
+        val binding = binding ?: return
+
+        binding.progressBar.visibility = if (state.loading) View.VISIBLE else View.GONE
+        binding.tvMsgDownloadedRecitersOnly.visibility =
+            if (state.showDownloadedOnlyMessage) View.VISIBLE else View.GONE
+        binding.tvMsgInternetConnectionFailed.visibility =
+            if (state.showNoInternetMessage) View.VISIBLE else View.GONE
+        binding.btnSelect.isEnabled = state.isSelectEnabled
+
+        if (binding.rvReciters.adapter == null && state.reciterNames.isNotEmpty()) {
+            binding.rvReciters.setHasFixedSize(true)
+            binding.rvReciters.layoutManager = LinearLayoutManager(
                 context, RecyclerView.VERTICAL, false
             )
-            binding!!.rvReciters.addItemDecoration(
+            binding.rvReciters.addItemDecoration(
                 DividerItemDecoration(
                     context, DividerItemDecoration.VERTICAL
                 )
             )
-            adapter = OptionsListAdapter(recitersNames, selectedReciterIndex, this)
-            binding!!.rvReciters.adapter = adapter
+            adapter = OptionsListAdapter(state.reciterNames, state.selectedReciterIndex, this)
+            binding.rvReciters.adapter = adapter
+        } else {
+            adapter?.setSelectedOptionIndex(state.selectedReciterIndex)
         }
     }
 
@@ -136,154 +164,22 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
         adjustDialogSize(this)
     }
 
-    override fun onStart() {
-        super.onStart()
-        val recitationKey: String = when (recitationId) {
-            Constants.Recitation.HAFS_ID -> Constants.Recitation.HAFS_KEY
-            Constants.Recitation.WARSH_ID -> Constants.Recitation.WARSH_KEY
-            else -> error("Invalid recitation id: $recitationId")
-        }
-        val disposable: Disposable = recitationsRepository.getRecitersForRecitation(recitationKey)
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribeOn(AndroidSchedulers.mainThread())
-            .subscribeWith(object : DisposableSingleObserver<List<ReciterModel>>() {
-
-                override fun onSuccess(reciters: List<ReciterModel>) {
-                    Log.d(TAG, "reciters: $reciters")
-                    if (isSafeFragment(this@QuranRecitersDialogFragment)) {
-                        if (reciters.isNotEmpty()) {
-                            reciterModels = reciters
-                            setupRecitersRecyclerView()
-                        } else {
-                            Log.e(TAG, "The fetched reciters list is empty!")
-                            Toast.makeText(
-                                requireContext(), R.string.no_reciters,
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        }
-                        binding!!.progressBar.visibility = View.GONE
-                    }
-                }
-
-                override fun onError(e: Throwable) {
-                    Log.e(TAG, "Error fetching reciters", e)
-                    if (isSafeFragment(this@QuranRecitersDialogFragment)) {
-
-                        // try to display the downloaded reciters
-                        loadRecitersFromDb()
-                    }
-                }
-            })
-        compositeDisposable.add(disposable)
-    }
-
-    @SuppressLint("StaticFieldLeak")
-    private fun loadRecitersFromDb() {
-        // TODO load from DB only for a selected aya, or page or sura, to guarantee reciter is downloaded
-        object : AsyncTask<Void?, Void?, List<ReciterModel>?>() {
-
-            override fun doInBackground(vararg voids: Void?): List<ReciterModel>? {
-                if (context != null) {
-                    val reciterDao = UserDatabase.getInstance(context!!).reciterDao
-                    val recitersList = reciterDao.getAllForRecitation(recitationId)
-
-                    // Convert from Reciter to ReciterModel
-                    val reciterModelsList: MutableList<ReciterModel> = ArrayList(recitersList.size)
-                    for (r in recitersList) {
-                        reciterModelsList.add(
-                            ReciterModel(
-                                id = r.id,
-                                localizedName = r.name,
-                                localizedNationality = r.nationality,
-                                audioBaseUrl = r.audioBaseUrl
-                            )
-                        )
-                    }
-                    return reciterModelsList
-                }
-                return null
-            }
-
-            override fun onPostExecute(recitersList: List<ReciterModel>?) {
-                if (recitersList != null &&
-                    isSafeFragment(this@QuranRecitersDialogFragment)
-                ) {
-                    reciterModels = recitersList
-                    if (reciterModels!!.isNotEmpty()) {
-                        binding!!.tvMsgDownloadedRecitersOnly.visibility = View.VISIBLE
-                        setupRecitersRecyclerView()
-                    } else {
-                        // User hasn't downloaded any Quran audio before
-                        binding!!.tvMsgInternetConnectionFailed.visibility = View.VISIBLE
-                    }
-                    binding!!.progressBar.visibility = View.GONE
-                }
-            }
-        }.execute()
-    }
-
     override fun onItemClick(clickedItemIndex: Int) {
-        selectedReciterIndex = clickedItemIndex
-        if (!binding!!.btnSelect.isEnabled) binding!!.btnSelect.isEnabled = true
+        viewModel.onReciterClicked(clickedItemIndex)
     }
 
     private fun onBackClick() {
         dismiss()
     }
 
-    @SuppressLint("StaticFieldLeak")
     private fun onSelectClick() {
-        val selectedReciterModel = reciterModels!![selectedReciterIndex]
-
-        object : AsyncTask<Void?, Void?, Void?>() {
-            override fun onPreExecute() {
-                binding!!.btnSelect.isEnabled = false
-            }
-
-            override fun doInBackground(vararg voids: Void?): Void? {
-                if (isSafeFragment(this@QuranRecitersDialogFragment)) {
-
-                    // Store selected reciter in DB
-                    val userDatabase = UserDatabase.getInstance(requireContext())
-                    if (userDatabase.reciterDao.getById(selectedReciterModel.id) == null) {
-                        userDatabase.reciterDao.insert(
-                            Reciter(
-                                selectedReciterModel.id,
-                                selectedReciterModel.getLocalizedName(requireContext()),
-                                selectedReciterModel.getLocalizedNationality(requireContext()),
-                                selectedReciterModel.audioBaseUrl
-                            )
-                        )
-                    }
-
-                    // persist selected reciter as preference if recitation id matches the one in preferences
-                    val recitationIdPreference =
-                        AppPreferencesManager.getRecitationSetting(requireContext())
-                    if (recitationIdPreference == recitationId) {
-                        AppPreferencesManager.persistReciterSheikhSetting(
-                            requireContext(),
-                            selectedReciterModel.id
-                        )
-                    }
-                }
-                return null
-            }
-
-            override fun onPostExecute(aVoid: Void?) {
-                reciterSelectionListener!!.onReciterSelected(recitationId, selectedReciterModel)
-                dismiss()
-            }
-        }.execute()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        compositeDisposable.dispose()
+        viewModel.onSelectClicked()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         binding = null
+        adapter = null
     }
 
     override fun onDetach() {
@@ -302,8 +198,6 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
 
     companion object {
 
-        private val TAG = QuranRecitersDialogFragment::class.java.simpleName
-
         private const val ARG_RECITATION_ID = "ARG_RECITATION_ID"
         private const val ARG_SELECTED_RECITER_ID = "ARG_SELECTED_RECITER_ID"
 
@@ -313,13 +207,6 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
          *
          * @param recitationId      A recitation ID as in [Constants.Recitation].
          * @param selectedReciterId The current selected reciter ID.
-         * @return A new instance of fragment QuranRecitersDialogFragment.
-         */
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param recitationId A recitation ID as in [Constants.Recitation].
          * @return A new instance of fragment QuranRecitersDialogFragment.
          */
         @JvmStatic

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/AudioDownloadAmountViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/AudioDownloadAmountViewModel.kt
@@ -4,10 +4,8 @@ import android.app.Application
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import app.quranhub.data.local.db.UserDatabase
-import app.quranhub.data.local.entity.ReciterRecitation
 import app.quranhub.data.service.QuranAudioDownloaderService
-import kotlinx.coroutines.Dispatchers
+import app.quranhub.util.QuranAudioDownloadUtils.registerReciterRecitation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +14,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for the Quran audio download-amount dialog: tracks the chosen
@@ -62,19 +59,8 @@ class AudioDownloadAmountViewModel(
     fun startDownload() {
         viewModelScope.launch {
             try {
-                withContext(Dispatchers.IO) {
-                    // Store SheikhRecitation for the downloaded recitation & reciter in DB
-                    val userDatabase = UserDatabase.getInstance(appContext)
-                    if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
-                        userDatabase.reciterRecitationDao
-                            .insert(
-                                ReciterRecitation(
-                                    recitationId = recitationId,
-                                    reciterId = reciterId
-                                )
-                            )
-                    }
-                }
+                // Store SheikhRecitation for the downloaded recitation & reciter in DB
+                registerReciterRecitation(appContext, recitationId, reciterId)
 
                 if (_uiState.value.selectedOption == OPTION_DOWNLOAD_SURA) {
                     QuranAudioDownloaderService.downloadSura(

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/AudioDownloadAmountViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/AudioDownloadAmountViewModel.kt
@@ -1,0 +1,101 @@
+package app.quranhub.ui.downloads_manager.viewmodel
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.data.local.entity.ReciterRecitation
+import app.quranhub.data.service.QuranAudioDownloaderService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * ViewModel for the Quran audio download-amount dialog: tracks the chosen
+ * download amount & sura, registers the reciter's recitation in the local
+ * database and starts the download.
+ */
+class AudioDownloadAmountViewModel(
+    application: Application,
+    private val recitationId: Int,
+    private val reciterId: String,
+    initialSuraId: Int
+) : AndroidViewModel(application) {
+
+    sealed interface AudioDownloadAmountEvent {
+        data object DownloadStarted : AudioDownloadAmountEvent
+    }
+
+    data class AudioDownloadAmountUiState(
+        val selectedOption: Int = OPTION_DOWNLOAD_SURA,
+        val suraId: Int = 1
+    )
+
+    private val appContext = application
+
+    private val _uiState = MutableStateFlow(AudioDownloadAmountUiState(suraId = initialSuraId))
+    val uiState: StateFlow<AudioDownloadAmountUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<AudioDownloadAmountEvent>(Channel.BUFFERED)
+    val events: Flow<AudioDownloadAmountEvent> = _events.receiveAsFlow()
+
+    fun onSuraSelected(suraId: Int) {
+        _uiState.update { it.copy(selectedOption = OPTION_DOWNLOAD_SURA, suraId = suraId) }
+    }
+
+    fun onSuraDownloadOptionSelected() {
+        _uiState.update { it.copy(selectedOption = OPTION_DOWNLOAD_SURA) }
+    }
+
+    fun onDownloadAllOptionSelected() {
+        _uiState.update { it.copy(selectedOption = OPTION_DOWNLOAD_ALL) }
+    }
+
+    fun startDownload() {
+        viewModelScope.launch {
+            try {
+                withContext(Dispatchers.IO) {
+                    // Store SheikhRecitation for the downloaded recitation & reciter in DB
+                    val userDatabase = UserDatabase.getInstance(appContext)
+                    if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
+                        userDatabase.reciterRecitationDao
+                            .insert(
+                                ReciterRecitation(
+                                    recitationId = recitationId,
+                                    reciterId = reciterId
+                                )
+                            )
+                    }
+                }
+
+                if (_uiState.value.selectedOption == OPTION_DOWNLOAD_SURA) {
+                    QuranAudioDownloaderService.downloadSura(
+                        appContext, recitationId, reciterId, _uiState.value.suraId
+                    )
+                } else {
+                    QuranAudioDownloaderService.downloadQuran(
+                        appContext, recitationId, reciterId
+                    )
+                }
+                _events.send(AudioDownloadAmountEvent.DownloadStarted)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start Quran audio download", e)
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = AudioDownloadAmountViewModel::class.java.simpleName
+
+        private const val OPTION_DOWNLOAD_SURA = 0
+        private const val OPTION_DOWNLOAD_ALL = 1
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/BaseDownloadsViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/BaseDownloadsViewModel.kt
@@ -1,0 +1,88 @@
+package app.quranhub.ui.downloads_manager.viewmodel
+
+import android.app.Application
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.quranhub.ui.downloads_manager.model.DisplayableDownload
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Base ViewModel for the download listing screens. Each screen loads its
+ * [DisplayableDownload] listing once at creation (and on [refresh]), exposed
+ * as StateFlow so the listing survives rotation.
+ */
+abstract class BaseDownloadsViewModel(application: Application) : AndroidViewModel(application) {
+
+    /**
+     * One-time events emitted to the hosting screen.
+     */
+    sealed interface DownloadsEvent {
+        data class OpenAudioDownloadAmountDialog(
+            val recitationId: Int,
+            val reciterId: String
+        ) : DownloadsEvent
+
+        data object DownloadStarted : DownloadsEvent
+    }
+
+    data class DownloadsUiState(
+        val loading: Boolean = true,
+        val downloads: List<DisplayableDownload> = emptyList()
+    )
+
+    protected val appContext: Context get() = getApplication()
+
+    private val _uiState = MutableStateFlow(DownloadsUiState())
+    val uiState: StateFlow<DownloadsUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<DownloadsEvent>(
+        capacity = Channel.BUFFERED,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val events: Flow<DownloadsEvent> = _events.receiveAsFlow()
+
+    init {
+        refresh()
+    }
+
+    /**
+     * Reloads the listing (used initially, on download completion and after
+     * a delete).
+     */
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(loading = true) }
+            try {
+                val downloads = withContext(workDispatcher) { loadDownloads() }
+                _uiState.update { it.copy(loading = false, downloads = downloads) }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load downloads", e)
+                _uiState.update { it.copy(loading = false, downloads = emptyList()) }
+            }
+        }
+    }
+
+    /** Runs on [workDispatcher]; pure data mapping, no UI access. */
+    protected abstract suspend fun loadDownloads(): List<DisplayableDownload>
+
+    protected suspend fun emitEvent(event: DownloadsEvent) {
+        _events.send(event)
+    }
+
+    companion object {
+        private val TAG = BaseDownloadsViewModel::class.java.simpleName
+
+        protected val workDispatcher = kotlinx.coroutines.Dispatchers.IO
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitationsViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitationsViewModel.kt
@@ -1,0 +1,52 @@
+package app.quranhub.ui.downloads_manager.viewmodel
+
+import android.app.Application
+import android.util.Log
+import app.quranhub.R
+import app.quranhub.data.Constants
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.ui.downloads_manager.model.DisplayableDownload
+import app.quranhub.util.QuranAudioDeleteUtils.deleteRecitationAudio
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class DownloadsRecitationsViewModel(application: Application) :
+    BaseDownloadsViewModel(application) {
+
+    override suspend fun loadDownloads(): List<DisplayableDownload> {
+        val context = appContext
+
+        val downloads: MutableList<DisplayableDownload> = ArrayList()
+
+        for (recitationStringResId in Constants.Recitation.NAMES_STR_IDS) {
+            downloads.add(DisplayableDownload(context.getString(recitationStringResId)))
+        }
+
+        // check if recitations are downloadable and/or deletable & the number of downloaded reciters each.
+        val reciterRecitationDao = UserDatabase.getInstance(context).reciterRecitationDao
+        for (i in downloads.indices) {
+            val displayableDownload = downloads[i]
+            val numOfDownloadedReciters = reciterRecitationDao.getNumOfRecitersWithDownloads(i)
+            displayableDownload.downloadedAmount =
+                context.getString(R.string.downloaded_reciters_num, numOfDownloadedReciters)
+            displayableDownload.isDeletable = numOfDownloadedReciters > 0
+            displayableDownload.isDownloadable = true // TODO check if it's not downloadable
+        }
+        return downloads
+    }
+
+    fun deleteRecitation(recitationId: Int) {
+        viewModelScope.launch {
+            try {
+                deleteRecitationAudio(appContext, recitationId)
+                refresh()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to delete recitation audio", e)
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = DownloadsRecitationsViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitersViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitersViewModel.kt
@@ -1,0 +1,118 @@
+package app.quranhub.ui.downloads_manager.viewmodel
+
+import android.app.Application
+import android.util.Log
+import app.quranhub.R
+import app.quranhub.data.Constants
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.data.local.entity.Reciter
+import app.quranhub.data.local.entity.ReciterRecitation
+import app.quranhub.data.repository.RecitationsRepository
+import app.quranhub.ui.downloads_manager.model.DisplayableDownload
+import app.quranhub.util.QuranAudioDeleteUtils.deleteReciterAudio
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class DownloadsRecitersViewModel(application: Application, private val recitationId: Int) :
+    BaseDownloadsViewModel(application) {
+
+    private val recitationsRepository = RecitationsRepository()
+
+    private var reciters: List<Reciter> = emptyList()
+
+    fun reciterAt(position: Int): Reciter = reciters[position]
+
+    override suspend fun loadDownloads(): List<DisplayableDownload> {
+        val context = appContext
+
+        val recitationKey: String = when (recitationId) {
+            Constants.Recitation.HAFS_ID -> Constants.Recitation.HAFS_KEY
+            Constants.Recitation.WARSH_ID -> Constants.Recitation.WARSH_KEY
+            else -> error("Invalid recitation id: $recitationId")
+        }
+
+        reciters = try {
+            val reciterModels =
+                recitationsRepository.getRecitersForRecitation(recitationKey).blockingGet()
+            if (reciterModels != null) {
+                reciterModels.map {
+                    Reciter(
+                        it.id,
+                        it.getLocalizedName(context),
+                        it.getLocalizedNationality(context),
+                        it.audioBaseUrl
+                    )
+                }
+            } else {
+                Log.e(TAG, "reciterModels is null!")
+                retrieveLocalReciters()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to retrieve reciters from RecitationsRepository.")
+            retrieveLocalReciters()
+        }
+
+        // process reciters list
+        val displayableDownloadsList: MutableList<DisplayableDownload> = mutableListOf()
+        val userDatabase = UserDatabase.getInstance(context)
+        for (r in reciters) {
+            val displayableDownload = DisplayableDownload(
+                r.name
+            )
+            val downloadedSurasIds = userDatabase.reciterRecitationDao
+                .getSurasIdsForReciterInRecitation(recitationId, r.id)
+            displayableDownload.downloadedAmount =
+                context.getString(R.string.downloaded_amount_suras, downloadedSurasIds.size)
+            displayableDownload.isDownloadable = downloadedSurasIds.size < 114
+            displayableDownload.isDeletable = downloadedSurasIds.isNotEmpty()
+            displayableDownloadsList.add(displayableDownload)
+        }
+        return displayableDownloadsList
+    }
+
+    private fun retrieveLocalReciters(): List<Reciter> {
+        return UserDatabase.getInstance(appContext)
+            .reciterDao.getAllForRecitation(recitationId)
+    }
+
+    fun deleteReciter(position: Int) {
+        viewModelScope.launch {
+            try {
+                deleteReciterAudio(appContext, recitationId, reciters[position].id)
+                refresh()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to delete reciter audio", e)
+            }
+        }
+    }
+
+    /**
+     * Registers the reciter (if needed) in the local database, then asks the
+     * screen to open the audio download-amount dialog for this reciter.
+     */
+    fun onDownloadItem(position: Int) {
+        viewModelScope.launch {
+            try {
+                val reciter = reciters[position]
+                val userDatabase = UserDatabase.getInstance(appContext)
+                if (userDatabase.reciterDao.getById(reciter.id) == null) {
+                    userDatabase.reciterDao.insert(reciter)
+                }
+                if (userDatabase.reciterRecitationDao[recitationId, reciter.id] == null) {
+                    userDatabase.reciterRecitationDao.insert(
+                        ReciterRecitation(recitationId = recitationId, reciterId = reciter.id)
+                    )
+                }
+                emitEvent(
+                    DownloadsEvent.OpenAudioDownloadAmountDialog(recitationId, reciter.id)
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to register reciter for download", e)
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = DownloadsRecitersViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitersViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitersViewModel.kt
@@ -33,19 +33,14 @@ class DownloadsRecitersViewModel(application: Application, private val recitatio
 
         reciters = try {
             val reciterModels =
-                recitationsRepository.getRecitersForRecitation(recitationKey).blockingGet()
-            if (reciterModels != null) {
-                reciterModels.map {
-                    Reciter(
-                        it.id,
-                        it.getLocalizedName(context),
-                        it.getLocalizedNationality(context),
-                        it.audioBaseUrl
-                    )
-                }
-            } else {
-                Log.e(TAG, "reciterModels is null!")
-                retrieveLocalReciters()
+                recitationsRepository.getRecitersForRecitation(recitationKey)
+            reciterModels.map {
+                Reciter(
+                    it.id,
+                    it.getLocalizedName(context),
+                    it.getLocalizedNationality(context),
+                    it.audioBaseUrl
+                )
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to retrieve reciters from RecitationsRepository.")

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitersViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsRecitersViewModel.kt
@@ -10,6 +10,7 @@ import app.quranhub.data.local.entity.ReciterRecitation
 import app.quranhub.data.repository.RecitationsRepository
 import app.quranhub.ui.downloads_manager.model.DisplayableDownload
 import app.quranhub.util.QuranAudioDeleteUtils.deleteReciterAudio
+import app.quranhub.util.QuranAudioDownloadUtils.registerReciterRecitation
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
@@ -25,11 +26,7 @@ class DownloadsRecitersViewModel(application: Application, private val recitatio
     override suspend fun loadDownloads(): List<DisplayableDownload> {
         val context = appContext
 
-        val recitationKey: String = when (recitationId) {
-            Constants.Recitation.HAFS_ID -> Constants.Recitation.HAFS_KEY
-            Constants.Recitation.WARSH_ID -> Constants.Recitation.WARSH_KEY
-            else -> error("Invalid recitation id: $recitationId")
-        }
+        val recitationKey = Constants.Recitation.keyForRecitation(recitationId)
 
         reciters = try {
             val reciterModels =
@@ -93,11 +90,7 @@ class DownloadsRecitersViewModel(application: Application, private val recitatio
                 if (userDatabase.reciterDao.getById(reciter.id) == null) {
                     userDatabase.reciterDao.insert(reciter)
                 }
-                if (userDatabase.reciterRecitationDao[recitationId, reciter.id] == null) {
-                    userDatabase.reciterRecitationDao.insert(
-                        ReciterRecitation(recitationId = recitationId, reciterId = reciter.id)
-                    )
-                }
+                registerReciterRecitation(appContext, recitationId, reciter.id)
                 emitEvent(
                     DownloadsEvent.OpenAudioDownloadAmountDialog(recitationId, reciter.id)
                 )

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsSurasViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsSurasViewModel.kt
@@ -4,11 +4,11 @@ import android.app.Application
 import android.util.Log
 import app.quranhub.R
 import app.quranhub.data.local.db.UserDatabase
-import app.quranhub.data.local.entity.ReciterRecitation
 import app.quranhub.data.local.prefs.AppPreferencesManager
 import app.quranhub.data.service.QuranAudioDownloaderService
 import app.quranhub.ui.downloads_manager.model.DisplayableDownload
 import app.quranhub.util.QuranAudioDeleteUtils.deleteSuraAudio
+import app.quranhub.util.QuranAudioDownloadUtils.registerReciterRecitation
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
@@ -52,15 +52,7 @@ class DownloadsSurasViewModel(
         viewModelScope.launch {
             try {
                 val suraId = position + 1
-                val userDatabase = UserDatabase.getInstance(appContext)
-                if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
-                    userDatabase.reciterRecitationDao.insert(
-                        ReciterRecitation(
-                            recitationId = recitationId,
-                            reciterId = reciterId
-                        )
-                    )
-                }
+                registerReciterRecitation(appContext, recitationId, reciterId)
                 val recitationIdPreference =
                     AppPreferencesManager.getRecitationSetting(appContext)
                 if (recitationIdPreference == recitationId) {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsSurasViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/DownloadsSurasViewModel.kt
@@ -1,0 +1,80 @@
+package app.quranhub.ui.downloads_manager.viewmodel
+
+import android.app.Application
+import android.util.Log
+import app.quranhub.R
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.data.local.entity.ReciterRecitation
+import app.quranhub.data.local.prefs.AppPreferencesManager
+import app.quranhub.data.service.QuranAudioDownloaderService
+import app.quranhub.ui.downloads_manager.model.DisplayableDownload
+import app.quranhub.util.QuranAudioDeleteUtils.deleteSuraAudio
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class DownloadsSurasViewModel(
+    application: Application,
+    private val recitationId: Int,
+    private val reciterId: String
+) : BaseDownloadsViewModel(application) {
+
+    override suspend fun loadDownloads(): List<DisplayableDownload> {
+        val context = appContext
+        val suras = context.resources.getStringArray(R.array.sura_name)
+        val quranAudioDao = UserDatabase.getInstance(context).quranAudioDao
+        val displayableDownloadList: MutableList<DisplayableDownload> = ArrayList()
+        for (i in suras.indices) {
+            val suraName = suras[i]
+            val displayableDownload = DisplayableDownload(suraName)
+            val suraId = i + 1
+            val isDownloadable = quranAudioDao
+                .getForSura(recitationId, reciterId, suraId)
+                .isEmpty()
+            displayableDownload.isDownloadable = isDownloadable
+            displayableDownload.isDeletable = !isDownloadable
+            displayableDownloadList.add(displayableDownload)
+        }
+        return displayableDownloadList
+    }
+
+    fun deleteSura(position: Int) {
+        viewModelScope.launch {
+            try {
+                deleteSuraAudio(appContext, recitationId, reciterId, position + 1)
+                refresh()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to delete sura audio", e)
+            }
+        }
+    }
+
+    fun downloadSura(position: Int) {
+        viewModelScope.launch {
+            try {
+                val suraId = position + 1
+                val userDatabase = UserDatabase.getInstance(appContext)
+                if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
+                    userDatabase.reciterRecitationDao.insert(
+                        ReciterRecitation(
+                            recitationId = recitationId,
+                            reciterId = reciterId
+                        )
+                    )
+                }
+                val recitationIdPreference =
+                    AppPreferencesManager.getRecitationSetting(appContext)
+                if (recitationIdPreference == recitationId) {
+                    AppPreferencesManager.persistReciterSheikhSetting(appContext, reciterId)
+                }
+                QuranAudioDownloaderService.downloadSura(appContext, recitationId, reciterId, suraId)
+                emitEvent(DownloadsEvent.DownloadStarted)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start sura download", e)
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = DownloadsSurasViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/ReciterPickerViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/ReciterPickerViewModel.kt
@@ -1,0 +1,195 @@
+package app.quranhub.ui.downloads_manager.viewmodel
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.quranhub.data.Constants
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.data.local.entity.Reciter
+import app.quranhub.data.local.prefs.AppPreferencesManager
+import app.quranhub.data.model.ReciterModel
+import app.quranhub.data.repository.RecitationsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * ViewModel for the Quran reciter picker dialog: loads the available reciters
+ * for a recitation (remote Firestore with a local-database fallback), tracks
+ * the user's selection and persists it on select.
+ */
+class ReciterPickerViewModel(
+    application: Application,
+    private val recitationId: Int,
+    private val selectedReciterId: String?
+) : AndroidViewModel(application) {
+
+    sealed interface ReciterPickerEvent {
+        data object NoReciters : ReciterPickerEvent
+        data class ReciterSelected(val recitationId: Int, val reciterModel: ReciterModel) :
+            ReciterPickerEvent
+    }
+
+    data class ReciterPickerUiState(
+        val loading: Boolean = true,
+        val reciterNames: List<String> = emptyList(),
+        val selectedReciterIndex: Int = -1,
+        val isSelectEnabled: Boolean = false,
+        val showDownloadedOnlyMessage: Boolean = false,
+        val showNoInternetMessage: Boolean = false
+    )
+
+    private val appContext = application
+
+    private val recitationsRepository = RecitationsRepository()
+
+    private var reciterModels: List<ReciterModel> = emptyList()
+
+    private val _uiState = MutableStateFlow(ReciterPickerUiState())
+    val uiState: StateFlow<ReciterPickerUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<ReciterPickerEvent>(Channel.BUFFERED)
+    val events: Flow<ReciterPickerEvent> = _events.receiveAsFlow()
+
+    init {
+        loadReciters()
+    }
+
+    fun loadReciters() {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    loading = true,
+                    showDownloadedOnlyMessage = false,
+                    showNoInternetMessage = false
+                )
+            }
+
+            val recitationKey: String = when (recitationId) {
+                Constants.Recitation.HAFS_ID -> Constants.Recitation.HAFS_KEY
+                Constants.Recitation.WARSH_ID -> Constants.Recitation.WARSH_KEY
+                else -> error("Invalid recitation id: $recitationId")
+            }
+
+            try {
+                val reciters =
+                    withContext(Dispatchers.IO) {
+                        recitationsRepository.getRecitersForRecitation(recitationKey)
+                    }
+                reciterModels = reciters
+                if (reciters.isNotEmpty()) {
+                    val preselectedIndex = reciters.indexOfFirst { it.id == selectedReciterId }
+                    _uiState.update {
+                        it.copy(
+                            loading = false,
+                            reciterNames = reciters.map { model ->
+                                model.getLocalizedName(appContext)
+                            },
+                            selectedReciterIndex = preselectedIndex,
+                            isSelectEnabled = preselectedIndex != -1
+                        )
+                    }
+                } else {
+                    Log.e(TAG, "The fetched reciters list is empty!")
+                    _uiState.update { it.copy(loading = false, reciterNames = emptyList()) }
+                    _events.send(ReciterPickerEvent.NoReciters)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching reciters", e)
+
+                // try to display the downloaded reciters
+                // TODO load from DB only for a selected aya, or page or sura, to guarantee reciter is downloaded
+                val localReciters = withContext(Dispatchers.IO) { loadRecitersFromDb() }
+                reciterModels = localReciters
+                _uiState.update { state ->
+                    state.copy(
+                        loading = false,
+                        reciterNames = localReciters.map { model ->
+                            model.getLocalizedName(appContext)
+                        },
+                        selectedReciterIndex = localReciters.indexOfFirst {
+                            it.id == selectedReciterId
+                        },
+                        showDownloadedOnlyMessage = localReciters.isNotEmpty(),
+                        showNoInternetMessage = localReciters.isEmpty()
+                    )
+                }
+            }
+        }
+    }
+
+    private fun loadRecitersFromDb(): List<ReciterModel> {
+        val recitersList = UserDatabase.getInstance(appContext)
+            .reciterDao
+            .getAllForRecitation(recitationId)
+
+        // Convert from Reciter to ReciterModel
+        return recitersList.map { r ->
+            ReciterModel(
+                id = r.id,
+                localizedName = r.name,
+                localizedNationality = r.nationality,
+                audioBaseUrl = r.audioBaseUrl
+            )
+        }
+    }
+
+    fun onReciterClicked(index: Int) {
+        _uiState.update {
+            it.copy(selectedReciterIndex = index, isSelectEnabled = true)
+        }
+    }
+
+    fun onSelectClicked() {
+        val state = _uiState.value
+        if (state.selectedReciterIndex == -1) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSelectEnabled = false) }
+            try {
+                val selectedReciterModel = reciterModels[state.selectedReciterIndex]
+                withContext(Dispatchers.IO) {
+                    // Store selected reciter in DB
+                    val userDatabase = UserDatabase.getInstance(appContext)
+                    if (userDatabase.reciterDao.getById(selectedReciterModel.id) == null) {
+                        userDatabase.reciterDao.insert(
+                            Reciter(
+                                selectedReciterModel.id,
+                                selectedReciterModel.getLocalizedName(appContext),
+                                selectedReciterModel.getLocalizedNationality(appContext),
+                                selectedReciterModel.audioBaseUrl
+                            )
+                        )
+                    }
+
+                    // persist selected reciter as preference if recitation id matches the one in preferences
+                    val recitationIdPreference =
+                        AppPreferencesManager.getRecitationSetting(appContext)
+                    if (recitationIdPreference == recitationId) {
+                        AppPreferencesManager.persistReciterSheikhSetting(
+                            appContext,
+                            selectedReciterModel.id
+                        )
+                    }
+                }
+                _events.send(
+                    ReciterPickerEvent.ReciterSelected(recitationId, selectedReciterModel)
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to persist selected reciter", e)
+                _uiState.update { it.copy(isSelectEnabled = true) }
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = ReciterPickerViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/ReciterPickerViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/viewmodel/ReciterPickerViewModel.kt
@@ -73,11 +73,7 @@ class ReciterPickerViewModel(
                 )
             }
 
-            val recitationKey: String = when (recitationId) {
-                Constants.Recitation.HAFS_ID -> Constants.Recitation.HAFS_KEY
-                Constants.Recitation.WARSH_ID -> Constants.Recitation.WARSH_KEY
-                else -> error("Invalid recitation id: $recitationId")
-            }
+            val recitationKey = Constants.Recitation.keyForRecitation(recitationId)
 
             try {
                 val reciters =

--- a/app/src/main/java/app/quranhub/ui/mushaf/AGENTS.md
+++ b/app/src/main/java/app/quranhub/ui/mushaf/AGENTS.md
@@ -33,7 +33,7 @@ This area is mid-migration from MVP to MVVM (see repo `.scratch/mvvm-migration/`
 ## Contracts & Invariants
 
 - Data access always goes through `interactor/*` interfaces; never import `data.local.db` DAOs into fragments/adapters.
-- Cross-fragment/service communication: audio playback state flows through the typed `flowholder/AudioPlaybackStateHolder` StateFlow (never via EventBus); the remaining greenrobot EventBus stream (download-finished) still requires matching `onStart`/`onStop` register/unregister pairs.
+- Cross-fragment/service communication: cross-component signaling flows through typed flow holders — `flowholder/AudioPlaybackStateHolder` (playback state), `flowholder/QuranPageClickHolder` (page taps), and `data/service/DownloadFinishedHolder` (downloader-service completion; collected with repeatOnLifecycle, no register/unregister pairs). There is no greenrobot EventBus usage in this area.
 - Async: legacy MVP code uses RxJava2; new MVVM code uses coroutines + Flow. Do not mix RxJava into new code.
 - Search/navigation depends on mushaf topology constants in `data/Constants` (aya counts, page mapping) — don't duplicate these.
 - Views are XML + ViewBinding only.

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafFragment.kt
@@ -30,7 +30,7 @@ import app.quranhub.data.local.entity.Aya
 import app.quranhub.data.local.entity.TranslationBook
 import app.quranhub.data.local.prefs.AppPreferencesManager
 import app.quranhub.data.model.ReciterModel
-import app.quranhub.data.service.QuranAudioDownloaderService.DownloadFinishEvent
+import app.quranhub.data.service.DownloadFinishedHolder
 import app.quranhub.databinding.FragmentMushafBinding
 import app.quranhub.ui.downloads_manager.dialogs.QuranRecitersDialogFragment
 import app.quranhub.ui.downloads_manager.dialogs.QuranRecitersDialogFragment.ReciterSelectionListener
@@ -68,9 +68,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCa
 import me.toptas.fancyshowcase.FancyShowCaseQueue
 import me.toptas.fancyshowcase.FancyShowCaseView
 import me.toptas.fancyshowcase.FocusShape
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -176,6 +173,7 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
         checkOrientationType()
         observeQuranPageClicks()
         observeAudioPlaybackState()
+        observeDownloadFinished()
     }
 
     // Toggle the mushaf chrome bars whenever the user taps a Quran page image
@@ -184,6 +182,16 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 QuranPageClickHolder.pageClicks.collect { viewModel.toggleBars() }
+            }
+        }
+    }
+
+    // Refresh the audio repeat-group setup when a downloader service finished
+    // its downloads (typed flow holder replacing the former DownloadFinishEvent)
+    private fun observeDownloadFinished() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                DownloadFinishedHolder.finished.collect { onDownloadAudioFinished() }
             }
         }
     }
@@ -410,18 +418,12 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
 
     override fun onStart() {
         super.onStart()
-        registerEventBus()
         setupMus7afShowcase()
     }
 
     override fun onPause() {
         super.onPause()
         saveInteger(requireActivity(), "last_open_page", quranPageIndex)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        unRegisterEventBus()
     }
 
     override fun onDestroyView() {
@@ -903,8 +905,7 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
     }
 
     // start audio of selected aya after it downloaded its sura audios
-    @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
-    fun onDownloadAudioFinished(event: DownloadFinishEvent?) {
+    private fun onDownloadAudioFinished() {
         if (!isAudioDialogOpen) return
         firstAyaInRepeatGroup = selectedAyaAudio!!.suraAya
         fromSuraDownloaded = selectedAyaAudio!!.sura
@@ -1036,14 +1037,6 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
         initAyaFromNotification = true
         notificationCurrentAya = aya
         binding.quranViewpager.currentItem = Constants.Quran.NUM_OF_PAGES - aya.page
-    }
-
-    private fun registerEventBus() {
-        if (!EventBus.getDefault().isRegistered(this)) EventBus.getDefault().register(this)
-    }
-
-    private fun unRegisterEventBus() {
-        if (EventBus.getDefault().isRegistered(this)) EventBus.getDefault().unregister(this)
     }
 
     // Playback-state subscriber: reflect audio states from the foreground

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsDataFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsDataFragment.kt
@@ -8,29 +8,25 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import app.quranhub.R
-import app.quranhub.data.local.db.UserDatabase
 import app.quranhub.data.local.entity.TranslationBook
 import app.quranhub.data.local.prefs.AppPreferencesManager.getQuranTranslationBook
 import app.quranhub.data.local.prefs.AppPreferencesManager.persistBookDbName
 import app.quranhub.data.local.prefs.AppPreferencesManager.persistBookName
 import app.quranhub.data.local.prefs.AppPreferencesManager.persistQuranTranslationBook
-import app.quranhub.data.remote.TranslationDownloader
-import app.quranhub.data.remote.TranslationDownloader.TranslationDownloadCallback
-import app.quranhub.data.repository.TranslationsRepository
 import app.quranhub.databinding.FragmentTranslationsDataBinding
 import app.quranhub.ui.common.interfaces.Searchable
 import app.quranhub.ui.mushaf.adapter.TranslationsAdapter
 import app.quranhub.ui.mushaf.model.DisplayableTranslation
-import app.quranhub.util.FragmentUtils.isSafeFragment
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
+import app.quranhub.ui.mushaf.viewmodel.TranslationsViewModel
 import kotlinx.coroutines.launch
 
 /**
@@ -38,21 +34,20 @@ import kotlinx.coroutines.launch
  * Use the [TranslationsDataFragment.newInstance] factory method to
  * create an instance of this fragment.
  */
-// TODO apply MVVM
-class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.ItemClickListener,
-    TranslationDownloadCallback {
+class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.ItemClickListener {
 
-    private val searchText = ""
     private var languageCode: String? = null
     private var listener: TranslationSelectionListener? = null
     private var binding: FragmentTranslationsDataBinding? = null
-    private var displayableTranslations: MutableList<DisplayableTranslation>? = null
     private var adapter: TranslationsAdapter? = null
-    private var remoteTranslationBooks: List<TranslationBook>? = null
-    private var translationBooksLiveData: LiveData<List<TranslationBook?>?>? = null
-    private var translationDownloaders: MutableList<TranslationDownloader>? = null
 
-    private val translationsRepository = TranslationsRepository()
+    private val viewModel: TranslationsViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                TranslationsViewModel(requireActivity().application, languageCode)
+            }
+        }
+    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -91,100 +86,47 @@ class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.Ite
             layoutManager.orientation
         )
         binding!!.rvTranslations.addItemDecoration(dividerItemDecoration)
-        displayableTranslations = ArrayList()
         adapter = TranslationsAdapter(
-            displayableTranslations,
+            ArrayList<DisplayableTranslation>(),
             getQuranTranslationBook(requireContext()),
             this
         )
         binding!!.rvTranslations.adapter = adapter
+        observeViewModel()
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        translationBooksLiveData = UserDatabase.getInstance(requireContext())
-            .translationBookDao
-            .getByLanguage(languageCode)
-        setupTranslationBooksLiveDataObserver()
-        fetchTranslationBooks()
-        translationDownloaders = ArrayList()
-        if (savedInstanceState != null) {
-            search(savedInstanceState.getString(STATE_SEARCH_TEXT))
-        }
-    }
-
-    private fun fetchTranslationBooks() {
+    private fun observeViewModel() {
         viewLifecycleOwner.lifecycleScope.launch {
-            translationsRepository.getTranslationsForLanguage(languageCode!!)
-                .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-                .catch {
-                    Log.e(TAG, "Error fetching translations", it)
-
-                    binding!!.progressTranslation.visibility = View.GONE
-
-                    Toast.makeText(
-                        context,
-                        getString(R.string.error_translations_web_service),
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
-                .collectLatest {
-                    remoteTranslationBooks = it
-                    for (book in remoteTranslationBooks!!) {
-                        val d = DisplayableTranslation(book)
-                        if (!displayableTranslations!!.contains(d)) {
-                            // only add if it's not there
-                            displayableTranslations!!.add(d)
-                        }
-                    }
-                    binding!!.progressTranslation.visibility = View.GONE
-                    adapter!!.setTranslations(displayableTranslations)
-                }
-        }
-    }
-
-    private fun setupTranslationBooksLiveDataObserver() {
-        translationBooksLiveData!!.observe(viewLifecycleOwner) { localTranslationBooks: List<TranslationBook?>? ->
-            Log.d(TAG, "translationBooksLiveData: localTranslationBooks = $localTranslationBooks")
-            if (displayableTranslations!!.size > 0) {
-                // there's a change in localTranslationBooks
-                // merge objects in remoteTranslationBooks & localTranslationBooks
-                displayableTranslations!!.clear()
-                for (book in localTranslationBooks!!) {
-                    displayableTranslations!!.add(DisplayableTranslation(book!!))
-                }
-                if (remoteTranslationBooks != null) {
-                    for (book in remoteTranslationBooks!!) {
-                        val d = DisplayableTranslation(book)
-                        if (!displayableTranslations!!.contains(d)) {
-                            // only add if it's not there
-                            displayableTranslations!!.add(d)
-                        }
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    viewModel.uiState.collect { state ->
+                        binding!!.progressTranslation.visibility =
+                            if (state.loading) View.VISIBLE else View.GONE
+                        adapter!!.setTranslations(state.translations.toMutableList())
                     }
                 }
-            } else {
-                // displayableTranslations is empty
-                // copy objects from localTranslationBooks
-                for (book in localTranslationBooks!!) {
-                    displayableTranslations!!.add(DisplayableTranslation(book!!))
+                launch {
+                    viewModel.events.collect { event ->
+                        when (event) {
+                            is TranslationsViewModel.TranslationsEvent.FetchFailed -> {
+                                Toast.makeText(
+                                    context,
+                                    getString(R.string.error_translations_web_service),
+                                    Toast.LENGTH_LONG
+                                ).show()
+                            }
+                            is TranslationsViewModel.TranslationsEvent.DownloadFailed -> {
+                                Toast.makeText(
+                                    context,
+                                    getString(R.string.error_download_translation),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                    }
                 }
             }
-            Log.d(
-                TAG,
-                "translationBooksLiveData: displayableTranslations = $displayableTranslations"
-            )
-            adapter!!.setTranslations(displayableTranslations)
         }
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putString(STATE_SEARCH_TEXT, searchText)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        binding = null
     }
 
     override fun onDetach() {
@@ -204,39 +146,14 @@ class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.Ite
         translationBook: TranslationBook?,
         clickedItemIndex: Int
     ) {
-        Log.d(TAG, "onDownloadTranslationClick: translationBook = $translationBook")
-        val downloader = TranslationDownloader(translationBook!!, requireContext(), this)
-        translationDownloaders!!.add(downloader)
-        downloader.download()
+        viewModel.downloadTranslation(translationBook!!)
     }
 
     override fun onCancelDownloadTranslationClick(
         translationBook: TranslationBook?,
         clickedItemIndex: Int
     ) {
-        Log.d(TAG, "onCancelDownloadTranslationClick: translationBook = $translationBook")
-        for (downloader in translationDownloaders!!) {
-            if (downloader.translationBook.id == translationBook!!.id) {
-                Log.d(TAG, "Download canceled for : " + translationBook.id)
-                downloader.cancel()
-                translationDownloaders!!.remove(downloader)
-                break
-            }
-        }
-    }
-
-    override fun onDownloadStarted() {}
-    override fun onDownloadFinished() {}
-    override fun onDownloadCancelled() {}
-
-    override fun onDownloadFailed() {
-        if (isSafeFragment(this)) {
-            Toast.makeText(
-                context,
-                getString(R.string.error_download_translation),
-                Toast.LENGTH_SHORT
-            ).show()
-        }
+        viewModel.cancelDownload(translationBook!!)
     }
 
     override fun search(text: String?) {
@@ -254,7 +171,6 @@ class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.Ite
         private val TAG = TranslationsDataFragment::class.java.simpleName
 
         private const val ARG_LANGUAGE_CODE = "ARG_LANGUAGE_CODE"
-        private const val STATE_SEARCH_TEXT = "STATE_SEARCH_TEXT"
 
         /**
          * Use this factory method to create a new instance of

--- a/app/src/main/java/app/quranhub/ui/mushaf/interactor/TranslationsInteractor.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/interactor/TranslationsInteractor.kt
@@ -1,0 +1,13 @@
+package app.quranhub.ui.mushaf.interactor
+
+import app.quranhub.data.local.entity.TranslationBook
+import kotlinx.coroutines.flow.Flow
+
+interface TranslationsInteractor {
+
+    fun getBooksForLanguage(langCode: String?): Flow<List<TranslationBook>>
+
+    suspend fun saveBook(book: TranslationBook)
+
+    suspend fun deleteBook(book: TranslationBook)
+}

--- a/app/src/main/java/app/quranhub/ui/mushaf/interactor/TranslationsInteractorImp.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/interactor/TranslationsInteractorImp.kt
@@ -1,0 +1,29 @@
+package app.quranhub.ui.mushaf.interactor
+
+import android.content.Context
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.data.local.entity.TranslationBook
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+class TranslationsInteractorImp(context: Context) : TranslationsInteractor {
+
+    private val userDatabase: UserDatabase = UserDatabase.getInstance(context.applicationContext)
+
+    override fun getBooksForLanguage(langCode: String?): Flow<List<TranslationBook>> {
+        return userDatabase.translationBookDao.getByLanguage(langCode)
+    }
+
+    override suspend fun saveBook(book: TranslationBook) {
+        withContext(Dispatchers.IO) {
+            userDatabase.translationBookDao.insert(book)
+        }
+    }
+
+    override suspend fun deleteBook(book: TranslationBook) {
+        withContext(Dispatchers.IO) {
+            userDatabase.translationBookDao.delete(book)
+        }
+    }
+}

--- a/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/TranslationsViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/TranslationsViewModel.kt
@@ -53,7 +53,7 @@ class TranslationsViewModel(
         override fun onDownloadFinished() {}
         override fun onDownloadCancelled() {}
         override fun onDownloadFailed() {
-            onDownloadFailed()
+            notifyDownloadFailed()
         }
     }
 
@@ -131,14 +131,14 @@ class TranslationsViewModel(
     }
 
     override fun onCleared() {
-        // cancel the downloader network requests; the downstream DB writes
-        // (deleting the cancelled download rows) are fast and complete on IO
+        // cancel the downloader network requests and their scopes; the
+        // cleanup DB deletes still run via NonCancellable
         downloaders.values.forEach { it.cancel() }
         downloaders.clear()
         super.onCleared()
     }
 
-    private fun onDownloadFailed() {
+    private fun notifyDownloadFailed() {
         viewModelScope.launch {
             _events.send(TranslationsEvent.DownloadFailed)
         }

--- a/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/TranslationsViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/TranslationsViewModel.kt
@@ -1,0 +1,150 @@
+package app.quranhub.ui.mushaf.viewmodel
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.quranhub.data.local.entity.TranslationBook
+import app.quranhub.data.remote.TranslationDownloader
+import app.quranhub.data.repository.TranslationsRepository
+import app.quranhub.ui.mushaf.interactor.TranslationsInteractor
+import app.quranhub.ui.mushaf.interactor.TranslationsInteractorImp
+import app.quranhub.ui.mushaf.model.DisplayableTranslation
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the translations library screen: merges the local (downloaded)
+ * translation books with the remote (available) ones and owns the
+ * translation downloaders, so the listing state survives rotation.
+ */
+class TranslationsViewModel(
+    application: Application,
+    private val languageCode: String?
+) : AndroidViewModel(application) {
+
+    sealed interface TranslationsEvent {
+        data object FetchFailed : TranslationsEvent
+        data object DownloadFailed : TranslationsEvent
+    }
+
+    data class TranslationsUiState(
+        val loading: Boolean = true,
+        val translations: List<DisplayableTranslation> = emptyList()
+    )
+
+    private val appContext = application
+
+    private val translationsRepository = TranslationsRepository()
+    private val translationsInteractor: TranslationsInteractor =
+        TranslationsInteractorImp(application)
+
+    private val downloaders = mutableMapOf<String, TranslationDownloader>()
+
+    private val callback = object : TranslationDownloader.TranslationDownloadCallback {
+        override fun onDownloadStarted() {}
+        override fun onDownloadFinished() {}
+        override fun onDownloadCancelled() {}
+        override fun onDownloadFailed() {
+            onDownloadFailed()
+        }
+    }
+
+    private val _uiState = MutableStateFlow(TranslationsUiState())
+    val uiState: StateFlow<TranslationsUiState> = _uiState.asStateFlow()
+
+    private val _events = Channel<TranslationsEvent>(Channel.BUFFERED)
+    val events: Flow<TranslationsEvent> = _events.receiveAsFlow()
+
+    // Latest remote (available) & local (downloaded) translation books
+    private val remoteBooks = MutableStateFlow<List<TranslationBook>>(emptyList())
+    private val localBooks = MutableStateFlow<List<TranslationBook>>(emptyList())
+
+    init {
+        observeLocalTranslationBooks()
+        mergeListing()
+        fetchTranslationBooks()
+    }
+
+    private fun observeLocalTranslationBooks() {
+        viewModelScope.launch {
+            translationsInteractor.getBooksForLanguage(languageCode)
+                .collect { books -> localBooks.value = books }
+        }
+    }
+
+    /** Merges remote & local books: downloaded books first, then remote ones not downloaded yet. */
+    private fun mergeListing() {
+        viewModelScope.launch {
+            combine(remoteBooks, localBooks) { remote, local ->
+                val displayableTranslations: MutableList<DisplayableTranslation> = ArrayList()
+                for (book in local) {
+                    displayableTranslations.add(DisplayableTranslation(book))
+                }
+                for (book in remote) {
+                    val d = DisplayableTranslation(book)
+                    if (!displayableTranslations.contains(d)) {
+                        // only add if it's not there
+                        displayableTranslations.add(d)
+                    }
+                }
+                displayableTranslations
+            }.collect { merged ->
+                _uiState.update { it.copy(translations = merged) }
+            }
+        }
+    }
+
+    private fun fetchTranslationBooks() {
+        viewModelScope.launch {
+            try {
+                translationsRepository.getTranslationsForLanguage(languageCode!!)
+                    .collect { translations ->
+                        remoteBooks.value = translations
+                        _uiState.update { it.copy(loading = false) }
+                    }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching translations", e)
+                _uiState.update { it.copy(loading = false) }
+                _events.send(TranslationsEvent.FetchFailed)
+            }
+        }
+    }
+
+    fun downloadTranslation(translationBook: TranslationBook) {
+        Log.d(TAG, "onDownloadTranslationClick: translationBook = $translationBook")
+        val downloader = TranslationDownloader(translationBook, appContext, callback)
+        downloaders[translationBook.id] = downloader
+        downloader.download()
+    }
+
+    fun cancelDownload(translationBook: TranslationBook) {
+        Log.d(TAG, "onCancelDownloadTranslationClick: translationBook = $translationBook")
+        downloaders.remove(translationBook.id)?.cancel()
+    }
+
+    override fun onCleared() {
+        // cancel the downloader network requests; the downstream DB writes
+        // (deleting the cancelled download rows) are fast and complete on IO
+        downloaders.values.forEach { it.cancel() }
+        downloaders.clear()
+        super.onCleared()
+    }
+
+    private fun onDownloadFailed() {
+        viewModelScope.launch {
+            _events.send(TranslationsEvent.DownloadFailed)
+        }
+    }
+
+    companion object {
+        private val TAG = TranslationsViewModel::class.java.simpleName
+    }
+}

--- a/app/src/main/java/app/quranhub/util/QuranAudioDeleteUtils.kt
+++ b/app/src/main/java/app/quranhub/util/QuranAudioDeleteUtils.kt
@@ -1,131 +1,98 @@
 package app.quranhub.util
 
 import android.content.Context
-import android.os.AsyncTask
 import app.quranhub.data.local.db.UserDatabase
 import app.quranhub.data.local.prefs.AppPreferencesManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 object QuranAudioDeleteUtils {
 
-    @JvmStatic
-    fun deleteRecitationAudio(
-        context: Context, recitationId: Int, deleteFinishListener: DeleteFinishListener
-    ) {
-        object : AsyncTask<Void?, Void?, Void?>() {
+    suspend fun deleteRecitationAudio(context: Context, recitationId: Int) {
+        withContext(Dispatchers.IO) {
 
-            override fun doInBackground(vararg voids: Void?): Void? {
-
-                // 1. delete from file system recitation folder with all of its contents
-                val recitationDirPath = QuranAudioFileUtils.getLocalDirPath(context, recitationId)
-                if (recitationDirPath != null) {
-                    val dir = File(recitationDirPath)
-                    if (dir.exists()) {
-                        deleteRecursive(dir)
-                    }
+            // 1. delete from file system recitation folder with all of its contents
+            val recitationDirPath = QuranAudioFileUtils.getLocalDirPath(context, recitationId)
+            if (recitationDirPath != null) {
+                val dir = File(recitationDirPath)
+                if (dir.exists()) {
+                    deleteRecursive(dir)
                 }
-
-                // 2. delete from DB
-                val userDatabase = UserDatabase.getInstance(context)
-                val reciters = userDatabase.reciterRecitationDao
-                    .getRecitersForRecitation(recitationId)
-                reciters?.filterNotNull()?.let {
-                    userDatabase.reciterDao.deleteAll(it.toTypedArray())
-                }
-
-                // 3. delete reciter preference if same recitation
-                val recitationIdPreference = AppPreferencesManager.getRecitationSetting(context)
-                if (recitationIdPreference == recitationId) {
-                    AppPreferencesManager.resetReciterSheikhSetting(context)
-                }
-                return null
             }
 
-            override fun onPostExecute(aVoid: Void?) {
-                deleteFinishListener.onDeleteFinish()
+            // 2. delete from DB
+            val userDatabase = UserDatabase.getInstance(context)
+            val reciters = userDatabase.reciterRecitationDao
+                .getRecitersForRecitation(recitationId)
+            reciters?.filterNotNull()?.let {
+                userDatabase.reciterDao.deleteAll(it.toTypedArray())
             }
-        }.execute()
+
+            // 3. delete reciter preference if same recitation
+            val recitationIdPreference = AppPreferencesManager.getRecitationSetting(context)
+            if (recitationIdPreference == recitationId) {
+                AppPreferencesManager.resetReciterSheikhSetting(context)
+            }
+        }
     }
 
-    @JvmStatic
-    fun deleteReciterAudio(
+    suspend fun deleteReciterAudio(
+        context: Context,
+        recitationId: Int,
+        reciterId: String
+    ) {
+        withContext(Dispatchers.IO) {
+
+            // 1. delete from file system the reciter folder for this recitation with all of its contents
+            val reciterDirPath = QuranAudioFileUtils.getLocalDirPath(
+                context, recitationId, reciterId
+            )
+            if (reciterDirPath != null) {
+                val dir = File(reciterDirPath)
+                if (dir.exists()) {
+                    deleteRecursive(dir)
+                }
+            }
+
+            // 2. delete from DB
+            val userDatabase = UserDatabase.getInstance(context)
+            userDatabase.reciterRecitationDao.delete(recitationId, reciterId)
+            // TODO delete also the reciter if he has no suras in any recitation
+        }
+    }
+
+    suspend fun deleteSuraAudio(
         context: Context,
         recitationId: Int,
         reciterId: String,
-        deleteFinishListener: DeleteFinishListener
+        suraId: Int
     ) {
-        object : AsyncTask<Void?, Void?, Void?>() {
-            override fun doInBackground(vararg voids: Void?): Void? {
+        withContext(Dispatchers.IO) {
+            val userDatabase = UserDatabase.getInstance(context)
 
-                // 1. delete from file system the reciter folder for this recitation with all of its contents
-                val reciterDirPath = QuranAudioFileUtils.getLocalDirPath(
-                    context, recitationId, reciterId
-                )
-                if (reciterDirPath != null) {
-                    val dir = File(reciterDirPath)
-                    if (dir.exists()) {
-                        deleteRecursive(dir)
+            // 1. delete from file system the reciter folder for this recitation with all of its contents
+            val quranAudios = userDatabase.quranAudioDao
+                .getForSura(recitationId, reciterId, suraId)
+            for (q in quranAudios) {
+                q?.let {
+                    val audioFilePath = context.getExternalFilesDir(null)!!.path + it.filePath
+                    val audioFile = File(audioFilePath)
+                    if (audioFile.exists()) {
+                        audioFile.delete()
                     }
                 }
-
-                // 2. delete from DB
-                val userDatabase = UserDatabase.getInstance(context)
-                userDatabase.reciterRecitationDao.delete(recitationId, reciterId)
-                // TODO delete also the reciter if he has no suras in any recitation
-                return null
             }
 
-            override fun onPostExecute(aVoid: Void?) {
-                deleteFinishListener.onDeleteFinish()
-            }
-        }.execute()
-    }
-
-    @JvmStatic
-    fun deleteSuraAudio(
-        context: Context,
-        recitationId: Int,
-        reciterId: String,
-        suraId: Int,
-        deleteFinishListener: DeleteFinishListener
-    ) {
-        object : AsyncTask<Void?, Void?, Void?>() {
-
-            override fun doInBackground(vararg voids: Void?): Void? {
-                val userDatabase = UserDatabase.getInstance(context)
-
-                // 1. delete from file system the reciter folder for this recitation with all of its contents
-                val quranAudios = userDatabase.quranAudioDao
-                    .getForSura(recitationId, reciterId, suraId)
-                for (q in quranAudios) {
-                    q?.let {
-                        val audioFilePath = context.getExternalFilesDir(null)!!.path + it.filePath
-                        val audioFile = File(audioFilePath)
-                        if (audioFile.exists()) {
-                            audioFile.delete()
-                        }
-                    }
-                }
-
-                // 2. delete from DB
-                userDatabase.quranAudioDao.deleteForSura(
-                    recitationId, reciterId, suraId
-                )
-                return null
-            }
-
-            override fun onPostExecute(aVoid: Void?) {
-                deleteFinishListener.onDeleteFinish()
-            }
-        }.execute()
+            // 2. delete from DB
+            userDatabase.quranAudioDao.deleteForSura(
+                recitationId, reciterId, suraId
+            )
+        }
     }
 
     private fun deleteRecursive(dir: File) {
         if (dir.isDirectory) for (child in dir.listFiles()) deleteRecursive(child)
         dir.delete()
-    }
-
-    interface DeleteFinishListener {
-        fun onDeleteFinish()
     }
 }

--- a/app/src/main/java/app/quranhub/util/QuranAudioDownloadUtils.kt
+++ b/app/src/main/java/app/quranhub/util/QuranAudioDownloadUtils.kt
@@ -1,8 +1,31 @@
 package app.quranhub.util
 
+import android.content.Context
 import app.quranhub.data.Constants
+import app.quranhub.data.local.db.UserDatabase
+import app.quranhub.data.local.entity.ReciterRecitation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 object QuranAudioDownloadUtils {
+
+    /**
+     * Registers the [ReciterRecitation] row for the given recitation & reciter
+     * in the local database, if it does not exist yet.
+     */
+    suspend fun registerReciterRecitation(context: Context, recitationId: Int, reciterId: String) {
+        withContext(Dispatchers.IO) {
+            val userDatabase = UserDatabase.getInstance(context)
+            if (userDatabase.reciterRecitationDao[recitationId, reciterId] == null) {
+                userDatabase.reciterRecitationDao.insert(
+                    ReciterRecitation(
+                        recitationId = recitationId,
+                        reciterId = reciterId
+                    )
+                )
+            }
+        }
+    }
 
     /**
      * Generates & returns the Quran audio file download URL relative path for the given args.


### PR DESCRIPTION
## Summary

Implements tickets **#258**, **#259**, and **#260** — three feature-slice commits of the MVP→MVVM migration spec (**#247**), each leaving `./gradlew build` green (the CI check).

### #258 — Downloads manager screens to MVVM
- Recitations/reciters/suras listings load via StateFlow ViewModels (`BaseDownloadsViewModel` + 3 subclasses); state survives rotation
- `QuranAudioDeleteUtils` AsyncTasks → suspend functions; delete flows run through the ViewModels
- Download-finished greenrobot EventBus event replaced by a typed SharedFlow holder (`data/service/DownloadFinishedHolder`), written by `QuranAudioDownloaderService` (minimal touch: Thread→coroutine, EventBus post→holder write); `BaseDownloadsFragment` and `MushafFragment` now collect the holder; the event class is deleted
- `DownloadsQuranImagesFragment` intentionally untouched — it has no listing/data to migrate (pure pass-through view)

### #259 — Reciter picker + download-amount dialogs to MVVM
- `RecitationsRepository` converts from Rx `Single` to a suspend function
- Reciter list load/selection/persistence runs through `ReciterPickerViewModel` (remote Firestore with local-DB fallback); download-amount choice persists through `AudioDownloadAmountViewModel`
- All Rx subscriptions and AsyncTasks removed from this feature; host-facing listener interfaces unchanged

### #260 — Translations screens to MVVM
- `TranslationsDataFragment` driven by `TranslationsViewModel`: local (downloaded) ⊕ remote (available) books merge in the ViewModel and render from StateFlow; `TODO apply MVVM` marker resolved
- `TranslationBookDao.getByLanguage` LiveData→Flow; new `TranslationsInteractor(+Imp)` keeps DAO access out of the UI layer
- `TranslationDownloader` raw Threads → structured coroutines on a dedicated IO scope; downloads cancelled via the ViewModel (`onCleared`)

### Review hardening (4th commit)
- Proper cancellation: downloader scopes cancelled with `NonCancellable` cleanup DB deletes; service scope cancelled in `onDestroy`
- Extracted duplicated reciter-recitation registration and recitation-id→key mapping
- Updated `ui/mushaf/AGENTS.md` (the download-finished EventBus stream no longer exists)

## Acceptance criteria
- [x] #258: listing screens load via ViewModels, survive rotation; delete via coroutines; completion refresh via typed SharedFlow; downloader service swaps behavior-preserving — *manual smoke test pending (needs device)*
- [x] #259: reciter list loads via ViewModel; reciter/amount choices persist; repository is suspend; no Rx in the feature — *manual smoke test pending*
- [x] #260: book availability/status renders from the ViewModel and survives rotation; progress flows through the ViewModel; downloader raw threads gone; TODO resolved — *manual smoke test pending*
- `./gradlew build` green (full lint+assemble+test), run once per ticket and after review fixes

## Notes / deliberate deviations
- The two #259 dialogs get dialog-scoped ViewModels instead of sharing host ViewModels: they serve two different hosts (`DownloadsManagerActivity` and `QuranPageFragment`); dialog-scoped VMs still survive rotation. `TranslationsDialogFragment` does share the host ViewModel via its hosted `TranslationsDataFragment`.
- Downloads ViewModels access `UserDatabase` DAOs directly (no interactor existed for this area; the interactor-seam rule is mushaf-scoped). Flagging for the #262 contract phase / agent-docs update.

Out of scope (separate tickets): mushaf-core/settings/wizard migrations, Rx/EventBus dependency removal (#262).

🟢 Verified: `./gradlew build` — same command as CI (`android.yml`). No test suite exists in this repo (scaffolding only); no schema or version bumps.