### PR TITLE
fix: reset Quran page zoom scale to exactly 1x

### DIFF
--- a/app/src/main/java/app/quranhub/data/local/prefs/AppPreferencesManager.kt
+++ b/app/src/main/java/app/quranhub/data/local/prefs/AppPreferencesManager.kt
@@ -3,6 +3,7 @@ package app.quranhub.data.local.prefs
 import android.content.Context
 import app.quranhub.data.Constants
 import app.quranhub.util.LocaleUtils.appLanguage
+import app.quranhub.util.QuranPageZoom
 import app.quranhub.util.SharedPrefsUtils.clearPreference
 import app.quranhub.util.SharedPrefsUtils.getBoolean
 import app.quranhub.util.SharedPrefsUtils.getFloat
@@ -40,13 +41,12 @@ object AppPreferencesManager {
 
     @JvmStatic
     fun getQuranPageZoomScaleSetting(context: Context): Float {
-        return getFloat(context, PREF_QURAN_PAGE_SCALE, 1f)
+        return QuranPageZoom.normalize(getFloat(context, PREF_QURAN_PAGE_SCALE, QuranPageZoom.MIN_SCALE))
     }
 
     @JvmStatic
     fun persistQuranPageZoomScaleSetting(context: Context, scale: Float) {
-        if (scale < 1f) return
-        saveFloat(context, PREF_QURAN_PAGE_SCALE, scale)
+        saveFloat(context, PREF_QURAN_PAGE_SCALE, QuranPageZoom.normalize(scale))
     }
 
     @JvmStatic

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafBottomBarFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafBottomBarFragment.kt
@@ -17,6 +17,7 @@ import app.quranhub.R
 import app.quranhub.databinding.FragmentMushafBottomBarBinding
 import app.quranhub.ui.mushaf.viewmodel.MushafViewModel
 import app.quranhub.util.InsetsUtils
+import app.quranhub.util.QuranPageZoom
 import kotlinx.coroutines.launch
 
 class MushafBottomBarFragment : Fragment() {
@@ -76,8 +77,8 @@ class MushafBottomBarFragment : Fragment() {
     }
 
     private fun setupZoomButtons() {
-        binding!!.ibZoomOut.isEnabled = quranPageZoomScaleFactor > 1f
-        binding!!.ibZoomIn.isEnabled = quranPageZoomScaleFactor < 1.5f
+        binding!!.ibZoomOut.isEnabled = QuranPageZoom.canZoomOut(quranPageZoomScaleFactor)
+        binding!!.ibZoomIn.isEnabled = QuranPageZoom.canZoomIn(quranPageZoomScaleFactor)
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -92,13 +93,13 @@ class MushafBottomBarFragment : Fragment() {
     }
 
     private fun zoomIn() {
-        quranPageZoomScaleFactor += ZOOM_SCALE_INCREMENT
+        quranPageZoomScaleFactor = QuranPageZoom.zoomIn(quranPageZoomScaleFactor)
         setupZoomButtons()
         footerCallbacks!!.updateQuranPageZoomScale(quranPageZoomScaleFactor)
     }
 
     private fun zoomOut() {
-        quranPageZoomScaleFactor -= ZOOM_SCALE_INCREMENT
+        quranPageZoomScaleFactor = QuranPageZoom.zoomOut(quranPageZoomScaleFactor)
         setupZoomButtons()
         footerCallbacks!!.updateQuranPageZoomScale(quranPageZoomScaleFactor)
     }
@@ -153,7 +154,5 @@ class MushafBottomBarFragment : Fragment() {
 
     companion object {
         private val TAG = MushafBottomBarFragment::class.java.simpleName
-
-        private const val ZOOM_SCALE_INCREMENT = 0.05f
     }
 }

--- a/app/src/main/java/app/quranhub/util/QuranPageZoom.kt
+++ b/app/src/main/java/app/quranhub/util/QuranPageZoom.kt
@@ -1,0 +1,42 @@
+package app.quranhub.util
+
+import kotlin.math.roundToInt
+
+/**
+ * Quran page zoom scale arithmetic.
+ *
+ * Zoom values are persisted and re-applied across app launches, so they must be
+ * free of floating-point drift: incrementing/decrementing raw floats
+ * (e.g. `1.05f - 0.05f == 0.99999994f`) would otherwise prevent the scale from
+ * ever returning to exactly 1x. All operations round to two decimal places and
+ * clamp to the valid scale range.
+ */
+object QuranPageZoom {
+
+    const val MIN_SCALE = 1f
+    const val MAX_SCALE = 1.5f
+    const val SCALE_INCREMENT = 0.05f
+
+    private const val SCALE_PRECISION = 100
+
+    fun normalize(scale: Float): Float {
+        val clamped = scale.coerceIn(MIN_SCALE, MAX_SCALE)
+        return (clamped * SCALE_PRECISION).roundToInt() / SCALE_PRECISION.toFloat()
+    }
+
+    fun zoomIn(currentScale: Float): Float {
+        return normalize(currentScale + SCALE_INCREMENT)
+    }
+
+    fun zoomOut(currentScale: Float): Float {
+        return normalize(currentScale - SCALE_INCREMENT)
+    }
+
+    fun canZoomIn(currentScale: Float): Boolean {
+        return currentScale < MAX_SCALE
+    }
+
+    fun canZoomOut(currentScale: Float): Boolean {
+        return currentScale > MIN_SCALE
+    }
+}

--- a/app/src/test/java/app/quranhub/util/QuranPageZoomTest.kt
+++ b/app/src/test/java/app/quranhub/util/QuranPageZoomTest.kt
@@ -1,0 +1,70 @@
+package app.quranhub.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class QuranPageZoomTest {
+
+    @Test
+    fun `normalize snaps drifted value below one back to one`() {
+        // Simulates float drift: 1.05f - 0.05f == 0.99999994f
+        val drifted = 1.05f - 0.05f
+        assertEquals(1f, QuranPageZoom.normalize(drifted), 0f)
+    }
+
+    @Test
+    fun `normalize keeps exact boundary values unchanged`() {
+        assertEquals(1f, QuranPageZoom.normalize(1f), 0f)
+        assertEquals(1.5f, QuranPageZoom.normalize(1.5f), 0f)
+    }
+
+    @Test
+    fun `normalize rounds to two decimal places`() {
+        assertEquals(1.05f, QuranPageZoom.normalize(1.0499999f), 0f)
+        assertEquals(1.1f, QuranPageZoom.normalize(1.1000001f), 0f)
+    }
+
+    @Test
+    fun `normalize clamps out of range values`() {
+        assertEquals(1f, QuranPageZoom.normalize(0.5f), 0f)
+        assertEquals(1.5f, QuranPageZoom.normalize(2f), 0f)
+    }
+
+    @Test
+    fun `zoom in then zoom out returns exactly one`() {
+        val zoomedIn = QuranPageZoom.zoomIn(1f)
+        assertEquals(1.05f, zoomedIn, 0f)
+        assertEquals(1f, QuranPageZoom.zoomOut(zoomedIn), 0f)
+    }
+
+    @Test
+    fun `zoom out at minimum stays at minimum`() {
+        assertEquals(1f, QuranPageZoom.zoomOut(1f), 0f)
+    }
+
+    @Test
+    fun `zoom in at maximum stays at maximum`() {
+        assertEquals(1.5f, QuranPageZoom.zoomIn(1.5f), 0f)
+    }
+
+    @Test
+    fun `ten zoom in steps reach exactly the maximum`() {
+        var scale = 1f
+        repeat(10) { scale = QuranPageZoom.zoomIn(scale) }
+        assertEquals(1.5f, scale, 0f)
+    }
+
+    @Test
+    fun `can zoom in below maximum but not at it`() {
+        assertEquals(true, QuranPageZoom.canZoomIn(1f))
+        assertEquals(true, QuranPageZoom.canZoomIn(1.45f))
+        assertEquals(false, QuranPageZoom.canZoomIn(1.5f))
+    }
+
+    @Test
+    fun `can zoom out above minimum but not at it`() {
+        assertEquals(true, QuranPageZoom.canZoomOut(1.5f))
+        assertEquals(true, QuranPageZoom.canZoomOut(1.05f))
+        assertEquals(false, QuranPageZoom.canZoomOut(1f))
+    }
+}


### PR DESCRIPTION
Fixes #169

## Problem
Zooming in on the Quran page and back out to the normal level (1x) did not persist 1x: after an app restart the page appeared slightly zoomed in.

## Root cause
`MushafBottomBarFragment` accumulated the zoom scale with raw float arithmetic (`scale += 0.05f` / `-= 0.05f`). Due to floating-point drift, `1.05f - 0.05f` evaluates to `0.99999994f`, and `AppPreferencesManager.persistQuranPageZoomScaleSetting` silently skipped persisting values below `1f` — leaving the last persisted scale at ~`1.05f`, which was restored on the next launch.

## Fix
- New pure helper `app.quranhub.util.QuranPageZoom` that owns zoom-scale arithmetic: `normalize` (clamps to `[1f, 1.5f]`, rounds to 2 decimal places), `zoomIn`/`zoomOut`, and `canZoomIn`/`canZoomOut` for button states.
- `MushafBottomBarFragment` computes zoom changes and button enable states through the helper (no more float accumulation).
- `AppPreferencesManager` normalizes on both read and write; removed the skip-below-1f guard so zooming back out persists exactly `1f`. Read-side normalization also repairs legacy drifted persisted values.

## Testing
- New JUnit test `QuranPageZoomTest` covering drift snapping, boundary clamping, incremental steps (10 zoom-ins reach exactly 1.5f), and the regression case *zoom in then zoom out returns exactly one*.
- `./gradlew build` passes (same as CI).