### PR TITLE
refactor: standardize ViewBinding access with non-null binding accessor

### DIFF
--- a/app/src/main/java/app/quranhub/ui/common/dialogs/OptionsListDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/common/dialogs/OptionsListDialogFragment.kt
@@ -26,7 +26,8 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
     private var options: List<String>? = null
     private var optionsThumbnailsDrawableIds: IntArray? = null
     private var selectedOptionIndex = 0
-    private var binding: DialogOptionsListBinding? = null
+    private var _binding: DialogOptionsListBinding? = null
+    private val binding get() = _binding!!
     private var itemSelectionListener: ItemSelectionListener? = null
 
     override fun onAttach(context: Context) {
@@ -61,18 +62,18 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
-        binding = DialogOptionsListBinding.inflate(inflater, container, false)
+        _binding = DialogOptionsListBinding.inflate(inflater, container, false)
         initDialogView()
-        return binding!!.root
+        return binding.root
     }
 
     private fun initDialogView() {
-        binding!!.tvTitle.text = dialogTitle
-        binding!!.rvOptions.setHasFixedSize(true)
-        binding!!.rvOptions.layoutManager = LinearLayoutManager(
+        binding.tvTitle.text = dialogTitle
+        binding.rvOptions.setHasFixedSize(true)
+        binding.rvOptions.layoutManager = LinearLayoutManager(
             context, RecyclerView.VERTICAL, false
         )
-        binding!!.rvOptions.addItemDecoration(
+        binding.rvOptions.addItemDecoration(
             DividerItemDecoration(
                 context, DividerItemDecoration.VERTICAL
             )
@@ -80,7 +81,7 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
         val adapter = OptionsListAdapter(
             options!!, optionsThumbnailsDrawableIds, selectedOptionIndex, this
         )
-        binding!!.rvOptions.adapter = adapter
+        binding.rvOptions.adapter = adapter
     }
 
     override fun onResume() {
@@ -90,7 +91,7 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override fun onDetach() {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/BaseDownloadsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/BaseDownloadsFragment.kt
@@ -37,7 +37,8 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
     /** The screen's ViewModel, providing the [DisplayableDownload] listing state. */
     protected abstract val viewModel: BaseDownloadsViewModel
 
-    private var binding: FragmentDownloadsBinding? = null
+    private var _binding: FragmentDownloadsBinding? = null
+    private val binding get() = _binding!!
 
     protected var downloadsAdapter: DownloadsAdapter? = null
         private set
@@ -72,8 +73,8 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentDownloadsBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentDownloadsBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -88,25 +89,25 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
 
     private fun setupDescription() {
         if (description != null) {
-            binding!!.tvDescription.text = description
+            binding.tvDescription.text = description
         } else {
-            binding!!.tvDescription.visibility = View.GONE
+            binding.tvDescription.visibility = View.GONE
         }
     }
 
     private fun setupDownloadsRecyclerView() {
-        binding!!.rvDownloads.setHasFixedSize(true)
+        binding.rvDownloads.setHasFixedSize(true)
         val layoutManager = LinearLayoutManager(requireContext())
-        binding!!.rvDownloads.layoutManager = layoutManager
+        binding.rvDownloads.layoutManager = layoutManager
 
         // add dividers between RecyclerView items
         val dividerItemDecoration = DividerItemDecoration(
             requireContext(),
             layoutManager.orientation
         )
-        binding!!.rvDownloads.addItemDecoration(dividerItemDecoration)
+        binding.rvDownloads.addItemDecoration(dividerItemDecoration)
         downloadsAdapter = DownloadsAdapter(emptyList<DisplayableDownload>(), this, editable)
-        binding!!.rvDownloads.adapter = downloadsAdapter
+        binding.rvDownloads.adapter = downloadsAdapter
     }
 
     private fun observeViewModel() {
@@ -114,7 +115,7 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.uiState.collect { state ->
-                        binding!!.progressBar.visibility =
+                        binding.progressBar.visibility =
                             if (state.loading) View.VISIBLE else View.GONE
                         if (!state.loading) {
                             Log.d(TAG, "Provided displayableDownloads=${state.downloads}")
@@ -141,7 +142,7 @@ abstract class BaseDownloadsFragment : Fragment(), Editable, DownloadsAdapter.It
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override var isEditable: Boolean

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/AudioDownloadAmountDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/AudioDownloadAmountDialogFragment.kt
@@ -39,7 +39,8 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
     private var recitationId = 0
     private var reciterId: String? = null
     private var suraId = 0 // [optional, defaults to 1]
-    private var binding: DialogAudioDownloadAmountBinding? = null
+    private var _binding: DialogAudioDownloadAmountBinding? = null
+    private val binding get() = _binding!!
     private var listener: AudioDownloadListener? = null
 
     private val viewModel: AudioDownloadAmountViewModel by viewModels {
@@ -87,9 +88,9 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         // Inflate the layout for this fragment
-        binding = DialogAudioDownloadAmountBinding.inflate(inflater, container, false)
+        _binding = DialogAudioDownloadAmountBinding.inflate(inflater, container, false)
         initDialogView()
-        return binding!!.root
+        return binding.root
     }
 
     private fun initDialogView() {
@@ -100,9 +101,9 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
             android.R.layout.simple_spinner_item, suras
         )
         dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        binding!!.spinnerSuras.adapter = dataAdapter
-        binding!!.spinnerSuras.setSelection(viewModel.uiState.value.suraId - 1)
-        binding!!.spinnerSuras.onItemSelectedListener =
+        binding.spinnerSuras.adapter = dataAdapter
+        binding.spinnerSuras.setSelection(viewModel.uiState.value.suraId - 1)
+        binding.spinnerSuras.onItemSelectedListener =
             object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(
                     parent: AdapterView<*>?,
@@ -134,18 +135,18 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     private fun attachListeners() {
-        binding!!.clOptionSuraDownload.setOnClickListener { v: View? ->
+        binding.clOptionSuraDownload.setOnClickListener { v: View? ->
             viewModel.onSuraDownloadOptionSelected()
         }
-        binding!!.clOptionDownloadAll.setOnClickListener { v: View? ->
+        binding.clOptionDownloadAll.setOnClickListener { v: View? ->
             viewModel.onDownloadAllOptionSelected()
         }
-        binding!!.btnCancel.setOnClickListener { v: View? -> onCancelButtonClick() }
-        binding!!.btnDownload.setOnClickListener { v: View? -> onDownloadButtonClick() }
+        binding.btnCancel.setOnClickListener { v: View? -> onCancelButtonClick() }
+        binding.btnDownload.setOnClickListener { v: View? -> onDownloadButtonClick() }
     }
 
     private fun observeViewModel() {
@@ -153,9 +154,9 @@ class AudioDownloadAmountDialogFragment : DialogFragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.uiState.collect { state ->
-                        binding?.ivCheckOptionSuraDownload?.visibility =
+                        _binding?.ivCheckOptionSuraDownload?.visibility =
                             if (state.selectedOption == OPTION_DOWNLOAD_SURA) View.VISIBLE else View.INVISIBLE
-                        binding?.ivCheckOptionDownloadAll?.visibility =
+                        _binding?.ivCheckOptionDownloadAll?.visibility =
                             if (state.selectedOption == OPTION_DOWNLOAD_ALL) View.VISIBLE else View.INVISIBLE
                     }
                 }

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/DeleteConfirmationDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/DeleteConfirmationDialogFragment.kt
@@ -23,7 +23,8 @@ class DeleteConfirmationDialogFragment : DialogFragment() {
     private var title: String? = null
     private var description: String? = null
     private var deletePosition = 0
-    private var binding: DialogConfirmationBinding? = null
+    private var _binding: DialogConfirmationBinding? = null
+    private val binding get() = _binding!!
     private var callbacks: DeleteConfirmationCallbacks? = null
 
     override fun onAttach(context: Context) {
@@ -61,14 +62,14 @@ class DeleteConfirmationDialogFragment : DialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         // Inflate the layout for this fragment
-        binding = DialogConfirmationBinding.inflate(inflater, container, false)
+        _binding = DialogConfirmationBinding.inflate(inflater, container, false)
         initDialogView()
-        return binding!!.root
+        return binding.root
     }
 
     private fun initDialogView() {
-        binding!!.tvTitle.text = title
-        binding!!.tvDescription.text = description
+        binding.tvTitle.text = title
+        binding.tvDescription.text = description
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -77,8 +78,8 @@ class DeleteConfirmationDialogFragment : DialogFragment() {
     }
 
     private fun attachListeners() {
-        binding!!.btnCancel.setOnClickListener { onCancelBtnClick() }
-        binding!!.btnConfirm.setOnClickListener { onConfirmBtnClick() }
+        binding.btnCancel.setOnClickListener { onCancelBtnClick() }
+        binding.btnConfirm.setOnClickListener { onConfirmBtnClick() }
     }
 
     override fun onResume() {
@@ -88,7 +89,7 @@ class DeleteConfirmationDialogFragment : DialogFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     private fun onCancelBtnClick() {

--- a/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/QuranRecitersDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/dialogs/QuranRecitersDialogFragment.kt
@@ -42,7 +42,8 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
 
     private var recitationId = 0
     private var selectedReciterId: String? = null
-    private var binding: DialogQuranRecitersBinding? = null
+    private var _binding: DialogQuranRecitersBinding? = null
+    private val binding get() = _binding!!
     private var adapter: OptionsListAdapter? = null
     private var reciterSelectionListener: ReciterSelectionListener? = null
 
@@ -89,17 +90,17 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DialogQuranRecitersBinding.inflate(inflater, container, false)
+        _binding = DialogQuranRecitersBinding.inflate(inflater, container, false)
         initDialogView()
-        return binding!!.root
+        return binding.root
     }
 
     private fun initDialogView() {
-        binding!!.tvMsgDownloadedRecitersOnly.visibility = View.GONE
-        binding!!.tvMsgInternetConnectionFailed.visibility = View.GONE
-        binding!!.btnSelect.isEnabled = false
-        binding!!.btnSelect.setOnClickListener { onSelectClick() }
-        binding!!.btnBack.setOnClickListener { onBackClick() }
+        binding.tvMsgDownloadedRecitersOnly.visibility = View.GONE
+        binding.tvMsgInternetConnectionFailed.visibility = View.GONE
+        binding.btnSelect.isEnabled = false
+        binding.btnSelect.setOnClickListener { onSelectClick() }
+        binding.btnBack.setOnClickListener { onBackClick() }
         observeViewModel()
     }
 
@@ -133,7 +134,7 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
     }
 
     private fun render(state: ReciterPickerViewModel.ReciterPickerUiState) {
-        val binding = binding ?: return
+        val binding = _binding ?: return
 
         binding.progressBar.visibility = if (state.loading) View.VISIBLE else View.GONE
         binding.tvMsgDownloadedRecitersOnly.visibility =
@@ -178,7 +179,7 @@ class QuranRecitersDialogFragment : DialogFragment(), OptionsListAdapter.ItemCli
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
         adapter = null
     }
 

--- a/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/FirstTimeWizardActivity.kt
@@ -29,7 +29,8 @@ import kotlinx.coroutines.launch
 
 class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
 
-    private var binding: ActivityFirstTimeWizardBinding? = null
+    private var _binding: ActivityFirstTimeWizardBinding? = null
+    private val binding get() = _binding!!
     private var wizardStepPagerAdapter: WizardStepPagerAdapter? = null
     private var layoutDir = View.LAYOUT_DIRECTION_LTR
     private var appliedSearchQuery: String? = null
@@ -44,15 +45,15 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityFirstTimeWizardBinding.inflate(layoutInflater)
-        setContentView(binding!!.root)
-        setSupportActionBar(binding!!.toolbar)
-        InsetsUtils.padTopForStatusBar(binding!!.appBar)
-        InsetsUtils.padBottomForNavigationBar(binding!!.clBottomBar)
+        _binding = ActivityFirstTimeWizardBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setSupportActionBar(binding.toolbar)
+        InsetsUtils.padTopForStatusBar(binding.appBar)
+        InsetsUtils.padBottomForNavigationBar(binding.clBottomBar)
         layoutDir = resources.configuration.layoutDirection
         wizardStepPagerAdapter = WizardStepPagerAdapter(supportFragmentManager)
-        binding!!.pagerSteps.adapter = wizardStepPagerAdapter
-        binding!!.pagerSteps.currentItem = pagerIndexOfStep(viewModel.currentStep.value)
+        binding.pagerSteps.adapter = wizardStepPagerAdapter
+        binding.pagerSteps.currentItem = pagerIndexOfStep(viewModel.currentStep.value)
         updateViews(viewModel.currentStep.value)
         attachListeners()
         observeViewModel()
@@ -64,8 +65,8 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
                 launch {
                     viewModel.currentStep.collect { step ->
                         val pagerIndex = pagerIndexOfStep(step)
-                        if (binding!!.pagerSteps.currentItem != pagerIndex) {
-                            binding!!.pagerSteps.currentItem = pagerIndex
+                        if (binding.pagerSteps.currentItem != pagerIndex) {
+                            binding.pagerSteps.currentItem = pagerIndex
                         }
                         updateViews(step)
                     }
@@ -76,12 +77,12 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
                         // query to its own options list
                         if (query != appliedSearchQuery) {
                             appliedSearchQuery = query
-                            if (binding!!.etSearch.text.toString() != query) {
+                            if (binding.etSearch.text.toString() != query) {
                                 if (query.isEmpty()) {
-                                    binding!!.etSearch.text.clear()
-                                    binding!!.etSearch.clearFocus()
+                                    binding.etSearch.text.clear()
+                                    binding.etSearch.clearFocus()
                                 } else {
-                                    binding!!.etSearch.setText(query)
+                                    binding.etSearch.setText(query)
                                 }
                             }
                         }
@@ -113,7 +114,7 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
     }
 
     private fun attachListeners() {
-        binding!!.pagerSteps.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
+        binding.pagerSteps.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
             override fun onPageScrolled(
                 position: Int,
                 positionOffset: Float,
@@ -128,7 +129,7 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
 
             override fun onPageScrollStateChanged(state: Int) {}
         })
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 viewModel.onSearchQueryChanged(s.toString())
@@ -136,8 +137,8 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
 
             override fun afterTextChanged(s: Editable) {}
         })
-        binding!!.btnBack.setOnClickListener { backButtonClicked() }
-        binding!!.btnNext.setOnClickListener { nextButtonClicked() }
+        binding.btnBack.setOnClickListener { backButtonClicked() }
+        binding.btnNext.setOnClickListener { nextButtonClicked() }
     }
 
     /**
@@ -171,7 +172,7 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
     private fun nextButtonClicked() {
         if (viewModel.currentStep.value == FirstTimeWizardViewModel.LAST_STEP) {
             // disable the button while finishing to avoid duplicate clicks
-            binding!!.btnNext.isEnabled = false
+            binding.btnNext.isEnabled = false
         }
         viewModel.onNextClicked()
     }
@@ -182,17 +183,17 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         when (currentStep) {
             FirstTimeWizardViewModel.FIRST_STEP -> {
                 title = getString(R.string.first_wizard_title_app_language_step)
-                binding!!.tvStepHint.setText(R.string.first_wizard_hint_app_langauge)
+                binding.tvStepHint.setText(R.string.first_wizard_hint_app_langauge)
             }
 
             FirstTimeWizardViewModel.TRANSLATIONS_STEP -> {
                 title = getString(R.string.first_wizard_title_translation_languages_step)
-                binding!!.tvStepHint.text = getString(R.string.first_wizard_hint_translation_languages)
+                binding.tvStepHint.text = getString(R.string.first_wizard_hint_translation_languages)
             }
 
             FirstTimeWizardViewModel.LAST_STEP -> {
                 title = getString(R.string.first_wizard_title_recitations_step)
-                binding!!.tvStepHint.text = getString(R.string.first_wizard_hint_recitations)
+                binding.tvStepHint.text = getString(R.string.first_wizard_hint_recitations)
             }
         }
 
@@ -202,16 +203,16 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         // update buttons
         if (currentStep == FirstTimeWizardViewModel.LAST_STEP) {
             // on last page
-            binding!!.btnNext.setText(R.string.finish)
-            binding!!.btnBack.isEnabled = true
+            binding.btnNext.setText(R.string.finish)
+            binding.btnBack.isEnabled = true
         } else if (currentStep == FirstTimeWizardViewModel.FIRST_STEP) {
             // on first page
-            binding!!.btnNext.setText(R.string.next)
-            binding!!.btnBack.isEnabled = false
+            binding.btnNext.setText(R.string.next)
+            binding.btnBack.isEnabled = false
         } else {
             // default
-            binding!!.btnNext.setText(R.string.next)
-            binding!!.btnBack.isEnabled = true
+            binding.btnNext.setText(R.string.next)
+            binding.btnBack.isEnabled = true
         }
     }
 
@@ -219,38 +220,38 @@ class FirstTimeWizardActivity : BaseActivity(), OnOptionClickListener {
         when (currentStep) {
             FirstTimeWizardViewModel.FIRST_STEP -> {
                 // first step
-                binding!!.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
-                binding!!.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
-                binding!!.separatorPages12.setBackgroundResource(R.color.color_control_highlight)
-                binding!!.ivProgressPage2.setImageDrawable(null)
-                binding!!.ivProgressPage2.setBackgroundResource(R.drawable.progress_circle_unchecked)
-                binding!!.separatorPages23.setBackgroundResource(R.color.color_control_highlight)
-                binding!!.ivProgressPage3.setImageDrawable(null)
-                binding!!.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_unchecked)
+                binding.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
+                binding.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
+                binding.separatorPages12.setBackgroundResource(R.color.color_control_highlight)
+                binding.ivProgressPage2.setImageDrawable(null)
+                binding.ivProgressPage2.setBackgroundResource(R.drawable.progress_circle_unchecked)
+                binding.separatorPages23.setBackgroundResource(R.color.color_control_highlight)
+                binding.ivProgressPage3.setImageDrawable(null)
+                binding.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_unchecked)
             }
 
             FirstTimeWizardViewModel.TRANSLATIONS_STEP -> {
                 // second step
-                binding!!.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
-                binding!!.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
-                binding!!.separatorPages12.setBackgroundResource(R.color.color_primary)
-                binding!!.ivProgressPage2.setImageResource(R.drawable.check_gold_ic)
-                binding!!.ivProgressPage2.setBackgroundResource(R.drawable.progress_circle_checked)
-                binding!!.separatorPages23.setBackgroundResource(R.color.color_control_highlight)
-                binding!!.ivProgressPage3.setImageDrawable(null)
-                binding!!.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_unchecked)
+                binding.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
+                binding.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
+                binding.separatorPages12.setBackgroundResource(R.color.color_primary)
+                binding.ivProgressPage2.setImageResource(R.drawable.check_gold_ic)
+                binding.ivProgressPage2.setBackgroundResource(R.drawable.progress_circle_checked)
+                binding.separatorPages23.setBackgroundResource(R.color.color_control_highlight)
+                binding.ivProgressPage3.setImageDrawable(null)
+                binding.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_unchecked)
             }
 
             FirstTimeWizardViewModel.LAST_STEP -> {
                 // last (third) step
-                binding!!.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
-                binding!!.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
-                binding!!.separatorPages12.setBackgroundResource(R.color.color_primary)
-                binding!!.ivProgressPage2.setImageResource(R.drawable.check_gold_ic)
-                binding!!.ivProgressPage2.setBackgroundResource(R.drawable.progress_circle_checked)
-                binding!!.separatorPages23.setBackgroundResource(R.color.color_primary)
-                binding!!.ivProgressPage3.setImageResource(R.drawable.check_gold_ic)
-                binding!!.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_checked)
+                binding.ivProgressPage1.setImageResource(R.drawable.check_gold_ic)
+                binding.ivProgressPage1.setBackgroundResource(R.drawable.progress_circle_checked)
+                binding.separatorPages12.setBackgroundResource(R.color.color_primary)
+                binding.ivProgressPage2.setImageResource(R.drawable.check_gold_ic)
+                binding.ivProgressPage2.setBackgroundResource(R.drawable.progress_circle_checked)
+                binding.separatorPages23.setBackgroundResource(R.color.color_primary)
+                binding.ivProgressPage3.setImageResource(R.drawable.check_gold_ic)
+                binding.ivProgressPage3.setBackgroundResource(R.drawable.progress_circle_checked)
             }
         }
     }

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListFragment.kt
@@ -35,7 +35,8 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
     private var listener: OnOptionClickListener? = null
     private var optionsListAdapter: OptionsListAdapter? = null
     private var searchText: String? = ""
-    private var binding: FragmentOptionsListBinding? = null
+    private var _binding: FragmentOptionsListBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,9 +53,9 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
         savedInstanceState: Bundle?
     ): View {
         // Inflate the layout for this fragment
-        binding = FragmentOptionsListBinding.inflate(inflater, container, false)
+        _binding = FragmentOptionsListBinding.inflate(inflater, container, false)
         initOptionsRecyclerView()
-        return binding!!.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -110,19 +111,19 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
     }
 
     private fun initOptionsRecyclerView() {
-        binding!!.rvOptions.setHasFixedSize(true)
-        binding!!.rvOptions.layoutManager = LinearLayoutManager(
+        binding.rvOptions.setHasFixedSize(true)
+        binding.rvOptions.layoutManager = LinearLayoutManager(
             context, RecyclerView.VERTICAL, false
         )
         val dividerItemDecoration = DividerItemDecoration(
             context,
             DividerItemDecoration.VERTICAL
         )
-        binding!!.rvOptions.addItemDecoration(dividerItemDecoration)
+        binding.rvOptions.addItemDecoration(dividerItemDecoration)
         optionsListAdapter = OptionsListAdapter(
             options, optionsThumbnailsDrawableIds, currentSelectedOptionIndex(), this
         )
-        binding!!.rvOptions.adapter = optionsListAdapter
+        binding.rvOptions.adapter = optionsListAdapter
     }
 
     /**
@@ -157,7 +158,7 @@ class OptionsListFragment : Fragment(), OptionsListAdapter.ItemClickListener, Se
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override fun onDetach() {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddBookmarkDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddBookmarkDialog.kt
@@ -19,7 +19,8 @@ import app.quranhub.util.DialogUtils.wrapDialogHeight
 
 class AddBookmarkDialog : DialogFragment(), ItemSelectionListener<Int> {
 
-    private var binding: DialogAddBookmarkBinding? = null
+    private var _binding: DialogAddBookmarkBinding? = null
+    private val binding get() = _binding!!
     private var dialog: Dialog? = null
     private var selectedType = 0
     private var bookmarkTypes: List<BookmarkType>? = null
@@ -38,7 +39,7 @@ class AddBookmarkDialog : DialogFragment(), ItemSelectionListener<Int> {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogAddBookmarkBinding.inflate(layoutInflater)
+        _binding = DialogAddBookmarkBinding.inflate(layoutInflater)
         bookmarkTypes = viewModel.uiState.value.bookmarkTypes
         initializeDialog()
         observeOnSelectedColor()
@@ -47,8 +48,8 @@ class AddBookmarkDialog : DialogFragment(), ItemSelectionListener<Int> {
 
     private fun observeOnSelectedColor() {
         val colors = requireActivity().resources.getIntArray(R.array.bookmark_colors)
-        binding!!.palette.setSelectedColor(colors[0])
-        binding!!.palette.setOnColorSelectedListener { color: Int ->
+        binding.palette.setSelectedColor(colors[0])
+        binding.palette.setOnColorSelectedListener { color: Int ->
             for (i in colors.indices) {
                 if (color == colors[i]) {
                     colorIndex = i
@@ -62,31 +63,31 @@ class AddBookmarkDialog : DialogFragment(), ItemSelectionListener<Int> {
     fun initializeDialog() {
         dialog = Dialog(requireActivity())
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         adapter = BookmarkTypeAdapter(bookmarkTypes, requireActivity(), this)
-        binding!!.bookmarkTypesRv.layoutManager = LinearLayoutManager(activity)
-        binding!!.bookmarkTypesRv.adapter = adapter
+        binding.bookmarkTypesRv.layoutManager = LinearLayoutManager(activity)
+        binding.bookmarkTypesRv.adapter = adapter
         selectedType = 1
         attachListeners()
     }
 
     private fun attachListeners() {
-        binding!!.addCustomGroup.setOnClickListener { onAddCustomBookmark() }
-        binding!!.btnShow.setOnClickListener { onShowFilterList() }
-        binding!!.btnBack.setOnClickListener { onBackDialog() }
+        binding.addCustomGroup.setOnClickListener { onAddCustomBookmark() }
+        binding.btnShow.setOnClickListener { onShowFilterList() }
+        binding.btnBack.setOnClickListener { onBackDialog() }
     }
 
     private fun onAddCustomBookmark() {
-        binding!!.addCustomCheckIv.visibility = View.VISIBLE
-        binding!!.customBookmarkGroup.visibility = View.VISIBLE
+        binding.addCustomCheckIv.visibility = View.VISIBLE
+        binding.customBookmarkGroup.visibility = View.VISIBLE
         adapter!!.hideCheck()
         isAddCustom = true
     }
 
     private fun onShowFilterList() {
         if (isAddCustom) {
-            if (binding!!.bookmarkTitleEt.text.toString().isEmpty()) {
+            if (binding.bookmarkTitleEt.text.toString().isEmpty()) {
                 Toast.makeText(
                     activity,
                     getString(R.string.enter_bookmark_title),
@@ -94,7 +95,7 @@ class AddBookmarkDialog : DialogFragment(), ItemSelectionListener<Int> {
                 ).show()
             } else {
                 viewModel.addCustomBookmark(
-                    binding!!.bookmarkTitleEt.text.toString(), colorIndex
+                    binding.bookmarkTitleEt.text.toString(), colorIndex
                 )
                 dismiss()
             }
@@ -111,11 +112,11 @@ class AddBookmarkDialog : DialogFragment(), ItemSelectionListener<Int> {
     override fun onSelectItem(type: Int) {
         selectedType = type
         isAddCustom = false
-        binding!!.addCustomCheckIv.visibility = View.GONE
+        binding.addCustomCheckIv.visibility = View.GONE
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 }

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddNoteDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddNoteDialog.kt
@@ -32,7 +32,8 @@ import java.io.IOException
 
 class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
 
-    private var binding: DialogAddNoteBinding? = null
+    private var _binding: DialogAddNoteBinding? = null
+    private val binding get() = _binding!!
 
     private var isRecord = false
     private var isPlaying = false
@@ -57,7 +58,7 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogAddNoteBinding.inflate(layoutInflater)
+        _binding = DialogAddNoteBinding.inflate(layoutInflater)
         initializeDialog()
         readArgs()
         listenToSeekbarChanges()
@@ -78,7 +79,7 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     fun initializeDialog() {
         dialog = Dialog(requireActivity())
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         dialog!!.setCanceledOnTouchOutside(false)
         permissions = arrayOf(Manifest.permission.RECORD_AUDIO)
@@ -93,16 +94,16 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
             if (note != null) {
                 isEditable = true
                 setEditView()
-                binding!!.saveBtn.text = getString(R.string.save)
+                binding.saveBtn.text = getString(R.string.save)
             }
         }
     }
 
     private fun setEditView() {
-        binding!!.tvTitle.text = getString(R.string.edit_note)
-        (binding!!.noteTypeGroup.getChildAt(note!!.noteType) as RadioButton).isChecked = true
+        binding.tvTitle.text = getString(R.string.edit_note)
+        (binding.noteTypeGroup.getChildAt(note!!.noteType) as RadioButton).isChecked = true
         if (note!!.noteText != null) {
-            binding!!.addNoteEt.setText(note!!.noteText)
+            binding.addNoteEt.setText(note!!.noteText)
         }
         if (note?.noteRecorderPath?.isNotEmpty() == true) {
             setAudioViewsVisible()
@@ -112,10 +113,10 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun setAudioViewsVisible() {
-        binding!!.voiceTimerTv.visibility = View.VISIBLE
-        binding!!.recordGroup.visibility = View.VISIBLE
-        binding!!.addRecorderIv.visibility = View.INVISIBLE
-        binding!!.voiceStatusTv.text = getString(R.string.voice_listen)
+        binding.voiceTimerTv.visibility = View.VISIBLE
+        binding.recordGroup.visibility = View.VISIBLE
+        binding.addRecorderIv.visibility = View.INVISIBLE
+        binding.voiceStatusTv.text = getString(R.string.voice_listen)
     }
 
     private fun createRecordingFile() {
@@ -131,15 +132,15 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun attachListeners() {
-        binding!!.saveBtn.setOnClickListener { onAddNote() }
-        binding!!.cancelBtn.setOnClickListener { onCancel() }
-        binding!!.addRecorderIv.setOnClickListener { onClickRecord() }
-        binding!!.playIv.setOnClickListener { onPlayRecorder() }
-        binding!!.removeRecordIv.setOnClickListener { onRemoveRecord() }
+        binding.saveBtn.setOnClickListener { onAddNote() }
+        binding.cancelBtn.setOnClickListener { onCancel() }
+        binding.addRecorderIv.setOnClickListener { onClickRecord() }
+        binding.playIv.setOnClickListener { onPlayRecorder() }
+        binding.removeRecordIv.setOnClickListener { onRemoveRecord() }
     }
 
     private fun onAddNote() {
-        if (TextUtils.isEmpty(binding!!.addNoteEt.text) && !isRecorderAttached && !isRecord) {
+        if (TextUtils.isEmpty(binding.addNoteEt.text) && !isRecorderAttached && !isRecord) {
             Toast.makeText(activity, getString(R.string.note_empty), Toast.LENGTH_LONG).show()
         } else {
             var path: String? = ""
@@ -148,14 +149,14 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
             } else {
                 deleteRecorderFile()
             }
-            val selectedType = binding!!.noteTypeGroup.indexOfChild(
-                binding!!.root.findViewById(binding!!.noteTypeGroup.checkedRadioButtonId)
+            val selectedType = binding.noteTypeGroup.indexOfChild(
+                binding.root.findViewById(binding.noteTypeGroup.checkedRadioButtonId)
             )
             listener!!.onAddNote(
                 Note(
                     ayaId,
                     selectedType,
-                    binding!!.addNoteEt.text.toString(),
+                    binding.addNoteEt.text.toString(),
                     path
                 ), isEditable
             )
@@ -212,26 +213,26 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
 
     private fun onPlayRecorder() {
         if (isPlaying) {
-            binding!!.playIv.setImageResource(R.drawable.player_play_white_ic)
+            binding.playIv.setImageResource(R.drawable.player_play_white_ic)
             recorderMediaHelper!!.pause()
         } else {
-            binding!!.playIv.setImageResource(R.drawable.ic_pause)
+            binding.playIv.setImageResource(R.drawable.ic_pause)
             recorderMediaHelper!!.play()
             recorderMediaHelper!!.startUpdatingAudioTime()
             if (firstPlay) {
                 firstPlay = false
-                binding!!.voiceTimerTv.text = "0:00"
+                binding.voiceTimerTv.text = "0:00"
             }
         }
         isPlaying = !isPlaying
     }
 
     private fun onRemoveRecord() {
-        binding!!.recordGroup.visibility = View.GONE
-        binding!!.voiceTimerTv.visibility = View.GONE
-        binding!!.addRecorderIv.visibility = View.VISIBLE
-        binding!!.addRecorderIv.setBackgroundResource(R.drawable.corner_primary_dialog)
-        binding!!.voiceStatusTv.text = getString(R.string.add_voice)
+        binding.recordGroup.visibility = View.GONE
+        binding.voiceTimerTv.visibility = View.GONE
+        binding.addRecorderIv.visibility = View.VISIBLE
+        binding.addRecorderIv.setBackgroundResource(R.drawable.corner_primary_dialog)
+        binding.voiceStatusTv.text = getString(R.string.add_voice)
         recorderMediaHelper!!.release()
         isRecorderAttached = false
     }
@@ -243,7 +244,7 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun listenToSeekbarChanges() {
-        binding!!.recorderProgress.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
+        binding.recorderProgress.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
             override fun onStartTrackingTouch(seekBar: SeekBar) {
                 userIsSeeking = true
             }
@@ -263,8 +264,8 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
 
     private fun initRecording() {
         isRecord = true
-        binding!!.addRecorderIv.setBackgroundResource(R.drawable.red_corner)
-        binding!!.voiceStatusTv.text = getString(R.string.voice_recorded)
+        binding.addRecorderIv.setBackgroundResource(R.drawable.red_corner)
+        binding.voiceStatusTv.text = getString(R.string.voice_recorded)
         startTimer()
         startRecord()
     }
@@ -284,14 +285,14 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun stopTimer() {
-        binding!!.recorderChronometer.visibility = View.GONE
-        binding!!.recorderChronometer.stop()
+        binding.recorderChronometer.visibility = View.GONE
+        binding.recorderChronometer.stop()
     }
 
     private fun startTimer() {
-        binding!!.recorderChronometer.visibility = View.VISIBLE
-        binding!!.recorderChronometer.base = SystemClock.elapsedRealtime()
-        binding!!.recorderChronometer.start()
+        binding.recorderChronometer.visibility = View.VISIBLE
+        binding.recorderChronometer.base = SystemClock.elapsedRealtime()
+        binding.recorderChronometer.start()
     }
 
     override fun onRequestPermissionsResult(
@@ -318,34 +319,34 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
         super.onDestroyView()
         listener!!.onDismissDialog()
         stopRecorderMedia()
-        binding = null
+        _binding = null
     }
 
     override fun onGetMaxDuration(duration: Int) {
-        binding!!.recorderProgress.max = duration
+        binding.recorderProgress.max = duration
     }
 
     override fun onPositionChanged(position: Int) {
         if (!userIsSeeking) {
             if (Build.VERSION.SDK_INT >= 24) {
-                binding!!.recorderProgress.setProgress(position, true)
+                binding.recorderProgress.setProgress(position, true)
             } else {
-                binding!!.recorderProgress.progress = position
+                binding.recorderProgress.progress = position
             }
         }
     }
 
     override fun onStateChanged(state: PlaybackState) {
         if (state == PlaybackState.COMPLETED) {
-            binding!!.recorderProgress.progress = 0
+            binding.recorderProgress.progress = 0
             isPlaying = false
             firstPlay = true
-            binding!!.playIv.setImageResource(R.drawable.player_play_white_ic)
+            binding.playIv.setImageResource(R.drawable.player_play_white_ic)
         }
     }
 
     override fun onUpdatedTime(time: String?) {
-        binding!!.voiceTimerTv.text = time
+        binding.voiceTimerTv.text = time
     }
 
     interface AddNoteListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaActionsDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaActionsDialog.kt
@@ -26,7 +26,8 @@ class AyaActionsDialog : DialogFragment() {
     private var yLocation = 0
     private var dialog: Dialog? = null
     private var ayaPropertiesListener: AyaPropertiesListener? = null
-    private var binding: DialogAyaPropertiesBinding? = null
+    private var _binding: DialogAyaPropertiesBinding? = null
+    private val binding get() = _binding!!
 
     // Shares the host page's ViewModel (UI shell over one ViewModel per feature)
     private val viewModel: QuranPageViewModel by lazy {
@@ -52,7 +53,7 @@ class AyaActionsDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogAyaPropertiesBinding.inflate(layoutInflater)
+        _binding = DialogAyaPropertiesBinding.inflate(layoutInflater)
         initializeDialog()
         observeAyaState()
         return dialog!!
@@ -83,7 +84,7 @@ class AyaActionsDialog : DialogFragment() {
         val layoutParams = dialog!!.window!!.attributes
         layoutParams.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
         layoutParams.y = yLocation
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         attachListeners()
     }
@@ -92,34 +93,34 @@ class AyaActionsDialog : DialogFragment() {
         // handle if set image after orientation change
         when (bookmarkModel.bookmarkTypeId) {
             Constants.BookmarkType.NOTE -> {
-                binding!!.bookmarkIv.setImageResource(R.drawable.bookmark_green_selected)
+                binding.bookmarkIv.setImageResource(R.drawable.bookmark_green_selected)
             }
 
             Constants.BookmarkType.MEMORIZE -> {
-                binding!!.bookmarkIv.setImageResource(R.drawable.bookmark_red_selected)
+                binding.bookmarkIv.setImageResource(R.drawable.bookmark_red_selected)
             }
 
             Constants.BookmarkType.RECITING -> {
-                binding!!.bookmarkIv.setImageResource(R.drawable.bookmark_gold_selected)
+                binding.bookmarkIv.setImageResource(R.drawable.bookmark_gold_selected)
             }
 
             Constants.BookmarkType.FAVORITE -> {
-                binding!!.bookmarkIv.setImageResource(R.drawable.fav_added__gold_ic)
+                binding.bookmarkIv.setImageResource(R.drawable.fav_added__gold_ic)
             }
 
             else -> {    // CUSTOM BOOKMARK
-                binding!!.bookmarkIv.setImageResource(R.drawable.bookmark_green_selected)
-                binding!!.bookmarkIv.setColorFilter(requireActivity().resources.getIntArray(R.array.bookmark_colors)[bookmarkModel.colorIndex])
+                binding.bookmarkIv.setImageResource(R.drawable.bookmark_green_selected)
+                binding.bookmarkIv.setColorFilter(requireActivity().resources.getIntArray(R.array.bookmark_colors)[bookmarkModel.colorIndex])
             }
         }
     }
 
     private fun attachListeners() {
-        binding!!.shareContainer.setOnClickListener { onShareClick() }
-        binding!!.faselContainer.setOnClickListener { onFasilClick() }
-        binding!!.listenContainer.setOnClickListener { onListenClick() }
-        binding!!.tafseerContainer.setOnClickListener { onTafserClick() }
-        binding!!.notesContainer.setOnClickListener { onNotesClick() }
+        binding.shareContainer.setOnClickListener { onShareClick() }
+        binding.faselContainer.setOnClickListener { onFasilClick() }
+        binding.listenContainer.setOnClickListener { onListenClick() }
+        binding.tafseerContainer.setOnClickListener { onTafserClick() }
+        binding.notesContainer.setOnClickListener { onNotesClick() }
     }
 
     private fun onShareClick() {
@@ -148,12 +149,12 @@ class AyaActionsDialog : DialogFragment() {
     }
 
     fun setAyaHasNote() {
-        binding!!.noteIv.setImageResource(R.drawable.notes_gold_sidemenu_ic)
+        binding.noteIv.setImageResource(R.drawable.notes_gold_sidemenu_ic)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     interface AyaPropertiesListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaAudioPopup.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaAudioPopup.kt
@@ -13,7 +13,8 @@ import app.quranhub.util.LocaleUtils.appLanguage
 class AyaAudioPopup(private val context: Context, private val listener: AyaAudioListener) {
 
     private var popupWindow: PopupWindow? = null
-    private var binding: AyaAudioViewBinding? = null
+    private var _binding: AyaAudioViewBinding? = null
+    private val binding get() = _binding!!
 
     init {
         setWindowView()
@@ -21,9 +22,9 @@ class AyaAudioPopup(private val context: Context, private val listener: AyaAudio
 
     private fun setWindowView() {
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        binding = AyaAudioViewBinding.inflate(inflater)
+        _binding = AyaAudioViewBinding.inflate(inflater)
         popupWindow = PopupWindow(
-            binding!!.root,
+            binding.root,
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
             false
@@ -36,8 +37,8 @@ class AyaAudioPopup(private val context: Context, private val listener: AyaAudio
 
     private fun setViewDirections() {
         if (appLanguage == "ar") {
-            binding!!.prevAyaIv.setImageResource(R.drawable.player_fast_forward_white_ic)
-            binding!!.nextAyaIv.setImageResource(R.drawable.player_fast_rewind_white_ic)
+            binding.prevAyaIv.setImageResource(R.drawable.player_fast_forward_white_ic)
+            binding.nextAyaIv.setImageResource(R.drawable.player_fast_rewind_white_ic)
         }
     }
 
@@ -53,13 +54,13 @@ class AyaAudioPopup(private val context: Context, private val listener: AyaAudio
     }
 
     private fun attachListeners() {
-        binding!!.playIv.setOnClickListener { onPlayAudio() }
-        binding!!.recordIv.setOnClickListener { onClickRecord() }
-        binding!!.nextAyaIv.setOnClickListener { playNextAya() }
-        binding!!.prevAyaIv.setOnClickListener { playPrevAya() }
-        binding!!.repeatIv.setOnClickListener { onClickRepeat() }
-        binding!!.reciterIv.setOnClickListener { onClickReciter() }
-        binding!!.stopIv.setOnClickListener { onClickStop() }
+        binding.playIv.setOnClickListener { onPlayAudio() }
+        binding.recordIv.setOnClickListener { onClickRecord() }
+        binding.nextAyaIv.setOnClickListener { playNextAya() }
+        binding.prevAyaIv.setOnClickListener { playPrevAya() }
+        binding.repeatIv.setOnClickListener { onClickRepeat() }
+        binding.reciterIv.setOnClickListener { onClickReciter() }
+        binding.stopIv.setOnClickListener { onClickStop() }
     }
 
     private fun onPlayAudio() {
@@ -98,18 +99,18 @@ class AyaAudioPopup(private val context: Context, private val listener: AyaAudio
 
     fun setRecordState(hasRecorder: Boolean) {
         if (hasRecorder) {
-            binding!!.recordIv.setImageResource(R.drawable.play_record)
+            binding.recordIv.setImageResource(R.drawable.play_record)
         } else {
-            binding!!.recordIv.setImageResource(R.drawable.player_record_white_ic)
+            binding.recordIv.setImageResource(R.drawable.player_record_white_ic)
         }
     }
 
     fun setPlayState() {
-        binding!!.playIv.setImageResource(R.drawable.ic_pause)
+        binding.playIv.setImageResource(R.drawable.ic_pause)
     }
 
     fun setPauseState() {
-        binding!!.playIv.setImageResource(R.drawable.player_play_white_ic)
+        binding.playIv.setImageResource(R.drawable.player_play_white_ic)
     }
 
     interface AyaAudioListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderDialog.kt
@@ -19,7 +19,8 @@ class AyaRecorderDialog : DialogFragment() {
     private var listener: StopRecordingListener? = null
     private var ayaId = 0
     private lateinit var voiceRecorderViewModel: VoiceRecorderViewModel
-    private var binding: DialogAyaRecorderBinding? = null
+    private var _binding: DialogAyaRecorderBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -27,7 +28,7 @@ class AyaRecorderDialog : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogAyaRecorderBinding.inflate(layoutInflater)
+        _binding = DialogAyaRecorderBinding.inflate(layoutInflater)
         readArgs()
         initializeDialog()
         initReorder(savedInstanceState == null)
@@ -47,7 +48,7 @@ class AyaRecorderDialog : DialogFragment() {
         super.onSaveInstanceState(outState)
         outState.putLong(
             "chronometer_time",
-            binding!!.recorderChronometer.base - SystemClock.elapsedRealtime()
+            binding.recorderChronometer.base - SystemClock.elapsedRealtime()
         )
     }
 
@@ -73,34 +74,34 @@ class AyaRecorderDialog : DialogFragment() {
         dialog!!.setCanceledOnTouchOutside(false)
         val layoutParams = dialog!!.window!!.attributes
         layoutParams.gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(R.color.transparent_color)
         attachListeners()
     }
 
     private fun startTimer(base: Long) {
-        binding!!.recorderChronometer.base = base
-        binding!!.recorderChronometer.start()
+        binding.recorderChronometer.base = base
+        binding.recorderChronometer.start()
     }
 
     private fun attachListeners() {
-        binding!!.stopRecordingView.setOnClickListener { v: View? -> onStopRecording() }
+        binding.stopRecordingView.setOnClickListener { v: View? -> onStopRecording() }
     }
 
     private fun onStopRecording() {
         voiceRecorderViewModel.releaseRecorder()
-        binding!!.recorderChronometer.stop()
+        binding.recorderChronometer.stop()
         listener!!.onStopRecording(voiceRecorderViewModel.outputRecorderPath)
         dismiss()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding!!.recorderChronometer.stop()
+        binding.recorderChronometer.stop()
         if (!requireActivity().isChangingConfigurations) {
             voiceRecorderViewModel.releaseRecorder()
         }
-        binding = null
+        _binding = null
     }
 
     interface StopRecordingListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderPlayerDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderPlayerDialog.kt
@@ -32,7 +32,8 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     private var userIsSeeking = false
     private var firstPlay = true
     private var userSelectedPosition = 0
-    private var binding: DialogPlayAyaRecorderBinding? = null
+    private var _binding: DialogPlayAyaRecorderBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -40,7 +41,7 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogPlayAyaRecorderBinding.inflate(layoutInflater)
+        _binding = DialogPlayAyaRecorderBinding.inflate(layoutInflater)
         initializeDialog()
         setRecordingFile()
         initSoundMedia()
@@ -59,7 +60,7 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
 
     private fun restorePlayingState() {
         if (isPlaying) {
-            binding!!.playIv.setImageResource(R.drawable.ic_pause)
+            binding.playIv.setImageResource(R.drawable.ic_pause)
             recorderMediaHelper!!.play()
         }
     }
@@ -75,7 +76,7 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
         val layoutParams = dialog!!.window!!.attributes
         layoutParams.gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         arguments?.let {
             ayaId = it.getInt(ARG_AYA_ID)
@@ -101,7 +102,7 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun listenToSeekbarChanges() {
-        binding!!.recorderProgress.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
+        binding.recorderProgress.setOnSeekBarChangeListener(object : OnSeekBarChangeListener {
             override fun onStartTrackingTouch(seekBar: SeekBar) {
                 userIsSeeking = true
             }
@@ -128,8 +129,8 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun attachListeners() {
-        binding!!.removeRecordIv.setOnClickListener { v: View? -> onRemoveRecorder() }
-        binding!!.playIv.setOnClickListener { v: View? -> onPlayRecorder() }
+        binding.removeRecordIv.setOnClickListener { v: View? -> onRemoveRecorder() }
+        binding.playIv.setOnClickListener { v: View? -> onPlayRecorder() }
     }
 
     private fun onRemoveRecorder() {
@@ -140,44 +141,44 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
 
     fun onPlayRecorder() {
         if (isPlaying) {
-            binding!!.playIv.setImageResource(R.drawable.player_play_white_ic)
+            binding.playIv.setImageResource(R.drawable.player_play_white_ic)
             recorderMediaHelper!!.pause()
         } else {
-            binding!!.playIv.setImageResource(R.drawable.ic_pause)
+            binding.playIv.setImageResource(R.drawable.ic_pause)
             recorderMediaHelper!!.play()
             recorderMediaHelper!!.startUpdatingAudioTime()
             if (firstPlay) {
                 firstPlay = false
-                binding!!.recorderTimeTv.text = "0:00"
+                binding.recorderTimeTv.text = "0:00"
             }
         }
         isPlaying = !isPlaying
     }
 
     override fun onGetMaxDuration(duration: Int) {
-        binding!!.recorderProgress.max = duration
+        binding.recorderProgress.max = duration
     }
 
     override fun onPositionChanged(position: Int) {
         if (!userIsSeeking) {
             if (Build.VERSION.SDK_INT >= 24) {
-                binding!!.recorderProgress.setProgress(position, true)
+                binding.recorderProgress.setProgress(position, true)
             } else {
-                binding!!.recorderProgress.progress = position
+                binding.recorderProgress.progress = position
             }
         }
     }
 
     override fun onUpdatedTime(time: String?) {
-        binding!!.recorderTimeTv.text = time
+        binding.recorderTimeTv.text = time
     }
 
     override fun onStateChanged(state: PlaybackState) {
         if (state == PlaybackState.COMPLETED) {
-            binding!!.recorderProgress.progress = 0
+            binding.recorderProgress.progress = 0
             isPlaying = false
             firstPlay = true
-            binding!!.playIv.setImageResource(R.drawable.player_play_white_ic)
+            binding.playIv.setImageResource(R.drawable.player_play_white_ic)
         }
     }
 
@@ -186,7 +187,7 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
         if (!requireActivity().isChangingConfigurations && recorderMediaHelper != null) {
             recorderMediaHelper!!.release()
         }
-        binding = null
+        _binding = null
     }
 
     interface AyaRecorderPlayerListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRepeatDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRepeatDialogFragment.kt
@@ -32,7 +32,8 @@ class AyaRepeatDialogFragment : DialogFragment() {
     private var toSuraNumber = 0
     private var fromUser = false
 
-    private var binding: DialogAyaRepeatBinding? = null
+    private var _binding: DialogAyaRepeatBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -40,7 +41,7 @@ class AyaRepeatDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogAyaRepeatBinding.inflate(layoutInflater)
+        _binding = DialogAyaRepeatBinding.inflate(layoutInflater)
         initializeDialog()
         readArgs()
         setFromToViews()
@@ -50,27 +51,27 @@ class AyaRepeatDialogFragment : DialogFragment() {
     }
 
     private fun observeOnInputEditText() {
-        binding!!.fromEt.addTextChangedListener(object : TextWatcher {
+        binding.fromEt.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 if (s.toString().isEmpty()) return
                 if (s.toString().toInt() > maxFromAyaNumber) {
-                    binding!!.fromEt.error = getString(R.string.enter_valid_aya)
+                    binding.fromEt.error = getString(R.string.enter_valid_aya)
                 } else {
-                    binding!!.fromEt.error = null
+                    binding.fromEt.error = null
                 }
             }
 
             override fun afterTextChanged(s: Editable) {}
         })
-        binding!!.toEt.addTextChangedListener(object : TextWatcher {
+        binding.toEt.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 if (s.toString().isEmpty()) return
                 if (s.toString().toInt() > maxToAyaNumber) {
-                    binding!!.toEt.error = getString(R.string.enter_valid_aya)
+                    binding.toEt.error = getString(R.string.enter_valid_aya)
                 } else {
-                    binding!!.toEt.error = null
+                    binding.toEt.error = null
                 }
             }
 
@@ -79,7 +80,7 @@ class AyaRepeatDialogFragment : DialogFragment() {
     }
 
     private fun observeSpinnerSelection() {
-        binding!!.fromAyaSp.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        binding.fromAyaSp.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(
                 parent: AdapterView<*>?,
                 view: View?,
@@ -93,14 +94,14 @@ class AyaRepeatDialogFragment : DialogFragment() {
                 }
                 maxFromAyaNumber = suraVersesNumberArrayList!![position].ayas
                 if (fromUser) {
-                    binding!!.fromEt.setText("1")
+                    binding.fromEt.setText("1")
                     fromSuraNumber = position
                 }
             }
 
             override fun onNothingSelected(parent: AdapterView<*>?) {}
         }
-        binding!!.toAyaSp.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        binding.toAyaSp.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(
                 parent: AdapterView<*>?,
                 view: View?,
@@ -112,7 +113,7 @@ class AyaRepeatDialogFragment : DialogFragment() {
                 )
                 maxToAyaNumber = suraVersesNumberArrayList!![position].ayas
                 if (fromUser) {
-                    binding!!.toEt.setText(maxToAyaNumber.toString())
+                    binding.toEt.setText(maxToAyaNumber.toString())
                     toSuraNumber = position
                 } else {
                     fromUser = true
@@ -130,23 +131,23 @@ class AyaRepeatDialogFragment : DialogFragment() {
             android.R.layout.simple_spinner_item, surahs
         )
         dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        binding!!.fromAyaSp.adapter = dataAdapter
-        binding!!.toAyaSp.adapter = dataAdapter
+        binding.fromAyaSp.adapter = dataAdapter
+        binding.toAyaSp.adapter = dataAdapter
         if (selectedAya != null) {
             lastAyaInPage = suraVersesNumberArrayList!![selectedAya!!.sura - 1].ayas
-            binding!!.fromEt.setText(selectedAya!!.suraAya.toString())
-            binding!!.toEt.setText(lastAyaInPage.toString())
-            binding!!.fromAyaSp.setSelection(selectedAya!!.sura - 1)
-            binding!!.toAyaSp.setSelection(selectedAya!!.sura - 1)
+            binding.fromEt.setText(selectedAya!!.suraAya.toString())
+            binding.toEt.setText(lastAyaInPage.toString())
+            binding.fromAyaSp.setSelection(selectedAya!!.sura - 1)
+            binding.toAyaSp.setSelection(selectedAya!!.sura - 1)
             maxFromAyaNumber = suraVersesNumberArrayList!![selectedAya!!.sura - 1].ayas
             maxToAyaNumber = maxFromAyaNumber
             fromSuraNumber = selectedAya!!.sura - 1
             toSuraNumber = fromSuraNumber
         } else {
-            binding!!.fromEt.setText("1")
-            binding!!.toEt.setText("1")
-            binding!!.fromAyaSp.setSelection(0)
-            binding!!.toAyaSp.setSelection(0)
+            binding.fromEt.setText("1")
+            binding.toEt.setText("1")
+            binding.fromAyaSp.setSelection(0)
+            binding.toAyaSp.setSelection(0)
             maxFromAyaNumber = suraVersesNumberArrayList!![0].ayas
             maxToAyaNumber = maxFromAyaNumber
             fromSuraNumber = 0
@@ -166,7 +167,7 @@ class AyaRepeatDialogFragment : DialogFragment() {
     fun initializeDialog() {
         dialog = Dialog(requireActivity())
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         dialog!!.setCanceledOnTouchOutside(false)
         attachListeners()
@@ -180,14 +181,14 @@ class AyaRepeatDialogFragment : DialogFragment() {
     }
 
     private fun attachListeners() {
-        binding!!.repeatBtn.setOnClickListener { v: View? -> onClickRepeat() }
-        binding!!.btnBack.setOnClickListener { v: View? -> onClickBack() }
+        binding.repeatBtn.setOnClickListener { v: View? -> onClickRepeat() }
+        binding.btnBack.setOnClickListener { v: View? -> onClickBack() }
     }
 
     private fun onClickRepeat() {
-        if (binding!!.fromEt.error != null || binding!!.toEt.error != null) {
+        if (binding.fromEt.error != null || binding.toEt.error != null) {
             Toast.makeText(activity, getString(R.string.enter_valid_aya), Toast.LENGTH_LONG).show()
-        } else if (binding!!.fromEt.text.toString().isEmpty() || binding!!.toEt.text.toString()
+        } else if (binding.fromEt.text.toString().isEmpty() || binding.toEt.text.toString()
                 .isEmpty()
         ) {
             Toast.makeText(activity, getString(R.string.enter_repeat_interval), Toast.LENGTH_LONG)
@@ -195,32 +196,32 @@ class AyaRepeatDialogFragment : DialogFragment() {
         } else if (fromSuraNumber > toSuraNumber) {
             Toast.makeText(activity, getString(R.string.invalid_repeat_interval), Toast.LENGTH_LONG)
                 .show()
-        } else if (fromSuraNumber == toSuraNumber && binding!!.fromEt.text.toString()
-                .toInt() > binding!!.toEt.text.toString().toInt()
+        } else if (fromSuraNumber == toSuraNumber && binding.fromEt.text.toString()
+                .toInt() > binding.toEt.text.toString().toInt()
         ) {
             Toast.makeText(activity, getString(R.string.enter_valid_aya), Toast.LENGTH_LONG).show()
         } else {
             val repeatModel = RepeatModel()
             repeatModel.fromSura = fromSuraNumber + 1
             repeatModel.fromAyaId =
-                getFromAyaId(binding!!.fromEt.text.toString().toInt(), fromSuraNumber + 1)
-            repeatModel.fromAya = binding!!.fromEt.text.toString().toInt()
+                getFromAyaId(binding.fromEt.text.toString().toInt(), fromSuraNumber + 1)
+            repeatModel.fromAya = binding.fromEt.text.toString().toInt()
             repeatModel.toSura = toSuraNumber + 1
             repeatModel.toAyaId =
-                getToAyaId(binding!!.toEt.text.toString().toInt(), toSuraNumber + 1)
-            repeatModel.toAya = binding!!.toEt.text.toString().toInt()
+                getToAyaId(binding.toEt.text.toString().toInt(), toSuraNumber + 1)
+            repeatModel.toAya = binding.toEt.text.toString().toInt()
             repeatModel.groupRepeatNum =
-                if (binding!!.ayaGroupNumberEt.text.toString().trim { it <= ' ' }
-                        .isEmpty() || binding!!.ayaGroupNumberEt.text.toString()
+                if (binding.ayaGroupNumberEt.text.toString().trim { it <= ' ' }
+                        .isEmpty() || binding.ayaGroupNumberEt.text.toString()
                         .toInt() == 0
-                ) 1 else binding!!.ayaGroupNumberEt.text.toString().trim { it <= ' ' }.toInt()
+                ) 1 else binding.ayaGroupNumberEt.text.toString().trim { it <= ' ' }.toInt()
             repeatModel.ayaRepeatNum =
-                if (binding!!.ayaGroupNumberEt.text.toString().trim { it <= ' ' }
-                        .isEmpty() || binding!!.ayaGroupNumberEt.text.toString()
+                if (binding.ayaGroupNumberEt.text.toString().trim { it <= ' ' }
+                        .isEmpty() || binding.ayaGroupNumberEt.text.toString()
                         .toInt() == 0
-                ) 1 else binding!!.ayaGroupNumberEt.text.toString().trim { it <= ' ' }.toInt()
-            repeatModel.delayTime = if (binding!!.delayEt.text.toString().trim { it <= ' ' }
-                    .isEmpty()) 1 else binding!!.delayEt.text.toString().trim { it <= ' ' }.toInt()
+                ) 1 else binding.ayaGroupNumberEt.text.toString().trim { it <= ' ' }.toInt()
+            repeatModel.delayTime = if (binding.delayEt.text.toString().trim { it <= ' ' }
+                    .isEmpty()) 1 else binding.delayEt.text.toString().trim { it <= ' ' }.toInt()
             listener!!.onAyasRepeat(repeatModel)
             dismiss()
         }
@@ -248,7 +249,7 @@ class AyaRepeatDialogFragment : DialogFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     interface AyaRepeatListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/BookmarkEditDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/BookmarkEditDialog.kt
@@ -24,7 +24,8 @@ class BookmarkEditDialog : DialogFragment(), ItemSelectionListener<Int> {
     private var adapter: BookmarkTypeAdapter? = null
     private var bookmarkTypes: List<BookmarkType>? = null
     private var editDialog = false
-    private var binding: DialogBookmarkFilterBinding? = null
+    private var _binding: DialogBookmarkFilterBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -38,7 +39,7 @@ class BookmarkEditDialog : DialogFragment(), ItemSelectionListener<Int> {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogBookmarkFilterBinding.inflate(layoutInflater)
+        _binding = DialogBookmarkFilterBinding.inflate(layoutInflater)
         readArgs()
         initializeDialog()
         setDialogTypeViews()
@@ -47,9 +48,9 @@ class BookmarkEditDialog : DialogFragment(), ItemSelectionListener<Int> {
 
     private fun setDialogTypeViews() {
         if (editDialog) {
-            binding!!.btnShow.text = getString(R.string.edit)
-            binding!!.allBookmarkCheckbox.visibility = View.GONE
-            binding!!.allBookmark.visibility = View.GONE
+            binding.btnShow.text = getString(R.string.edit)
+            binding.allBookmarkCheckbox.visibility = View.GONE
+            binding.allBookmark.visibility = View.GONE
         }
     }
 
@@ -69,28 +70,28 @@ class BookmarkEditDialog : DialogFragment(), ItemSelectionListener<Int> {
     fun initializeDialog() {
         dialog = Dialog(requireActivity())
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         adapter = BookmarkTypeAdapter(bookmarkTypes, requireContext(), this)
-        binding!!.bookmarkTypesRv.layoutManager = LinearLayoutManager(activity)
-        binding!!.bookmarkTypesRv.adapter = adapter
+        binding.bookmarkTypesRv.layoutManager = LinearLayoutManager(activity)
+        binding.bookmarkTypesRv.adapter = adapter
         if (selectedFilter == 0) {
             adapter!!.hideCheck()
         } else {
-            binding!!.allBookmarkCheckbox.visibility = View.GONE
+            binding.allBookmarkCheckbox.visibility = View.GONE
             adapter!!.setTypeCheck(selectedFilter)
         }
         attachListeners()
     }
 
     private fun attachListeners() {
-        binding!!.allBookmark.setOnClickListener { onSelectAllBookmark() }
-        binding!!.btnShow.setOnClickListener { onShowFilterList() }
-        binding!!.btnBack.setOnClickListener { onBackDialog() }
+        binding.allBookmark.setOnClickListener { onSelectAllBookmark() }
+        binding.btnShow.setOnClickListener { onShowFilterList() }
+        binding.btnBack.setOnClickListener { onBackDialog() }
     }
 
     private fun onSelectAllBookmark() {
-        binding!!.allBookmarkCheckbox.visibility = View.VISIBLE
+        binding.allBookmarkCheckbox.visibility = View.VISIBLE
         adapter!!.hideCheck()
         selectedFilter = ALL_BOOKMARK_FILTER
     }
@@ -105,7 +106,7 @@ class BookmarkEditDialog : DialogFragment(), ItemSelectionListener<Int> {
     }
 
     override fun onSelectItem(bookmarkType: Int) {
-        binding!!.allBookmarkCheckbox.visibility = View.GONE
+        binding.allBookmarkCheckbox.visibility = View.GONE
         selectedFilter = bookmarkType
         bookmarkColorIndex = bookmarkTypes!![selectedFilter - 1].colorIndex
     }

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/NotesFilterDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/NotesFilterDialog.kt
@@ -20,7 +20,8 @@ class NotesFilterDialog : DialogFragment(), OptionClickListener {
     private var selectedOption = 0
     private var adapter: FilterAdapter? = null
     private var options: Array<String> = arrayOf()
-    private var binding: DialogNoteFilterBinding? = null
+    private var _binding: DialogNoteFilterBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -28,7 +29,7 @@ class NotesFilterDialog : DialogFragment(), OptionClickListener {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogNoteFilterBinding.inflate(layoutInflater)
+        _binding = DialogNoteFilterBinding.inflate(layoutInflater)
         initializeDialog()
         setFilterOptions()
         initViews()
@@ -45,15 +46,15 @@ class NotesFilterDialog : DialogFragment(), OptionClickListener {
     }
 
     private fun initViews() {
-        binding!!.noteFilterRv.layoutManager = LinearLayoutManager(activity)
+        binding.noteFilterRv.layoutManager = LinearLayoutManager(activity)
         adapter = FilterAdapter(Arrays.asList(*options), options[selectedOption], this, 0)
-        binding!!.noteFilterRv.adapter = adapter
+        binding.noteFilterRv.adapter = adapter
     }
 
     fun initializeDialog() {
         dialog = Dialog(requireActivity())
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(android.R.color.transparent)
         arguments?.let {
             selectedOption = it.getInt(NOTE_TYPE_ARGS)
@@ -79,7 +80,7 @@ class NotesFilterDialog : DialogFragment(), OptionClickListener {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/OptionDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/OptionDialog.kt
@@ -24,7 +24,8 @@ class OptionDialog : DialogFragment(), OptionClickListener {
     private var options: ArrayList<String>? = null
     private var requestCode = 0
 
-    private var binding: DialogSuraListBinding? = null
+    private var _binding: DialogSuraListBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -32,7 +33,7 @@ class OptionDialog : DialogFragment(), OptionClickListener {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        binding = DialogSuraListBinding.inflate(layoutInflater)
+        _binding = DialogSuraListBinding.inflate(layoutInflater)
         initializeDialog()
         setRecyclerList()
         observeOnInputSearch()
@@ -49,7 +50,7 @@ class OptionDialog : DialogFragment(), OptionClickListener {
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 adapter!!.filter(s.toString())
@@ -61,26 +62,26 @@ class OptionDialog : DialogFragment(), OptionClickListener {
 
     private fun setRecyclerList() {
         adapter = FilterAdapter(options!!, suraName!!, this, requestCode)
-        binding!!.suraRv.layoutManager = LinearLayoutManager(activity)
-        binding!!.suraRv.addItemDecoration(
+        binding.suraRv.layoutManager = LinearLayoutManager(activity)
+        binding.suraRv.addItemDecoration(
             DividerItemDecoration(
                 requireContext(),
                 DividerItemDecoration.VERTICAL
             )
         )
-        binding!!.suraRv.adapter = adapter
+        binding.suraRv.adapter = adapter
     }
 
     private fun initializeDialog() {
         dialog = Dialog(requireActivity())
         dialog!!.window!!.requestFeature(Window.FEATURE_NO_TITLE)
-        dialog!!.setContentView(binding!!.root)
+        dialog!!.setContentView(binding.root)
         dialog!!.window?.setBackgroundDrawableResource(R.color.transparent_color)
         arguments?.let {
             suraName = it.getString(SURA_NAME_ARGS)
             options = it.getStringArrayList(ALL_ITEMS_ARGS)
             requestCode = it.getInt(CODE_ARGS, 1)
-            binding!!.tvTitle.text = it.getString(HEADER_ARGS)
+            binding.tvTitle.text = it.getString(HEADER_ARGS)
         }
     }
 
@@ -91,7 +92,7 @@ class OptionDialog : DialogFragment(), OptionClickListener {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     interface ItemClickListener {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/BookmarksFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/BookmarksFragment.kt
@@ -25,7 +25,8 @@ import kotlinx.coroutines.launch
 
 class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
 
-    private var binding: FragmentBookmarksBinding? = null
+    private var _binding: FragmentBookmarksBinding? = null
+    private val binding get() = _binding!!
 
     private lateinit var viewModel: BookmarksViewModel
     private var navDrawerListener: ToolbarActionsListener? = null
@@ -56,9 +57,9 @@ class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
     ): View {
 
         // Inflate the layout for this fragment
-        binding = FragmentBookmarksBinding.inflate(inflater, container, false)
+        _binding = FragmentBookmarksBinding.inflate(inflater, container, false)
         viewModel = ViewModelProvider(this)[BookmarksViewModel::class.java]
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 viewModel.onSearchQueryChanged(s.toString())
@@ -66,12 +67,12 @@ class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
 
             override fun afterTextChanged(s: Editable) {}
         })
-        return binding!!.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         bookmarksListFragment = BookmarksListFragment.newInstance()
         val transaction = childFragmentManager.beginTransaction()
         transaction.replace(R.id.list_container, bookmarksListFragment!!)
@@ -86,27 +87,27 @@ class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
                 launch {
                     viewModel.uiState.collect { uiState ->
                         if (uiState.isEditMode) {
-                            binding!!.editBtn.visibility = View.INVISIBLE
-                            binding!!.ibFinishEdit.visibility = View.VISIBLE
-                            binding!!.filterBtn.visibility = View.INVISIBLE
+                            binding.editBtn.visibility = View.INVISIBLE
+                            binding.ibFinishEdit.visibility = View.VISIBLE
+                            binding.filterBtn.visibility = View.INVISIBLE
                         } else {
-                            binding!!.editBtn.visibility = View.VISIBLE
-                            binding!!.ibFinishEdit.visibility = View.INVISIBLE
-                            binding!!.filterBtn.visibility = View.VISIBLE
+                            binding.editBtn.visibility = View.VISIBLE
+                            binding.ibFinishEdit.visibility = View.INVISIBLE
+                            binding.filterBtn.visibility = View.VISIBLE
                         }
                         if (uiState.isListEditable) {
-                            binding!!.editBtn.setImageResource(R.drawable.edit_gold_ic)
-                            binding!!.editBtn.setColorFilter(null)
-                            binding!!.filterBtn.setColorFilter(null)
+                            binding.editBtn.setImageResource(R.drawable.edit_gold_ic)
+                            binding.editBtn.setColorFilter(null)
+                            binding.filterBtn.setColorFilter(null)
                         } else {
-                            binding!!.editBtn.setImageResource(R.drawable.edit_gold_ic)
-                            binding!!.editBtn.setColorFilter(
+                            binding.editBtn.setImageResource(R.drawable.edit_gold_ic)
+                            binding.editBtn.setColorFilter(
                                 ContextCompat.getColor(
                                     requireContext(),
                                     R.color.dark_grey
                                 )
                             )
-                            binding!!.filterBtn.setColorFilter(
+                            binding.filterBtn.setColorFilter(
                                 ContextCompat.getColor(
                                     requireContext(),
                                     R.color.dark_grey
@@ -131,10 +132,10 @@ class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
     }
 
     private fun attachListeners() {
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
-        binding!!.editBtn.setOnClickListener { edit() }
-        binding!!.filterBtn.setOnClickListener { filter() }
-        binding!!.ibFinishEdit.setOnClickListener { finishEdit() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.editBtn.setOnClickListener { edit() }
+        binding.filterBtn.setOnClickListener { filter() }
+        binding.ibFinishEdit.setOnClickListener { finishEdit() }
     }
 
     private fun onNavHamburgerClick() {
@@ -166,13 +167,13 @@ class BookmarksFragment : Fragment(), QuranNavigationCallbacks {
     }
 
     override fun gotoQuranPageAya(pageNumber: Int, ayaId: Int, addToBackStack: Boolean) {
-        dismissKeyboard(requireActivity(), binding!!.etSearch)
+        dismissKeyboard(requireActivity(), binding.etSearch)
         quranNavigationCallbacks!!.gotoQuranPageAya(pageNumber, ayaId, false)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/BookmarksListFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/BookmarksListFragment.kt
@@ -35,7 +35,8 @@ class BookmarksListFragment : Fragment(), BookmarkActionListener, BookmarkFilter
     private lateinit var bookMarksViewModel: BookmarksViewModel
     private var quranNavigationCallbacks: QuranNavigationCallbacks? = null
     private var editedBookmarkId = -1
-    private var binding: FragmentBookmarksListBinding? = null
+    private var _binding: FragmentBookmarksListBinding? = null
+    private val binding get() = _binding!!
     private var adapter: BookmarksAdapter? = null
     private var lastAppliedSearchQuery: String? = null
     private var lastAppliedFilterType = -1
@@ -57,9 +58,9 @@ class BookmarksListFragment : Fragment(), BookmarkActionListener, BookmarkFilter
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentBookmarksListBinding.inflate(inflater, container, false)
+        _binding = FragmentBookmarksListBinding.inflate(inflater, container, false)
         setupBookmarksRecyclerView()
-        return binding!!.root
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -76,14 +77,14 @@ class BookmarksListFragment : Fragment(), BookmarkActionListener, BookmarkFilter
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     bookMarksViewModel.uiState.collect { uiState ->
-                        binding!!.loadingIndicator.visibility =
+                        binding.loadingIndicator.visibility =
                             if (uiState.loading) View.VISIBLE else View.GONE
                         val bookmarksChanged = uiState.bookmarks != lastRenderedBookmarks
                         renderBookmarks(uiState.bookmarks)
                         lastRenderedBookmarks = uiState.bookmarks
                         applyListState(uiState.searchQuery, uiState.filterType, bookmarksChanged)
                         applyEditMode(uiState.isEditMode)
-                        binding!!.tvEmptyListMsg.visibility =
+                        binding.tvEmptyListMsg.visibility =
                             if (uiState.bookmarks.isEmpty()) View.VISIBLE else View.GONE
                     }
                 }
@@ -117,18 +118,18 @@ class BookmarksListFragment : Fragment(), BookmarkActionListener, BookmarkFilter
     }
 
     private fun setupBookmarksRecyclerView() {
-        binding!!.bookmarksRv.addItemDecoration(
+        binding.bookmarksRv.addItemDecoration(
             DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
         )
-        binding!!.bookmarksRv.setHasFixedSize(true)
-        binding!!.bookmarksRv.layoutManager = LinearLayoutManager(context)
+        binding.bookmarksRv.setHasFixedSize(true)
+        binding.bookmarksRv.layoutManager = LinearLayoutManager(context)
         adapter = BookmarksAdapter(requireContext(), this)
-        binding!!.bookmarksRv.adapter = adapter
+        binding.bookmarksRv.adapter = adapter
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override fun onSelectItem(displayableBookmark: DisplayableBookmark?) {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/Guz2IndexFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/Guz2IndexFragment.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.launch
  */
 class Guz2IndexFragment : Fragment(), IndexItemClickListener {
 
-    private var binding: FragmentGuz2IndexBinding? = null
+    private var _binding: FragmentGuz2IndexBinding? = null
+    private val binding get() = _binding!!
 
     private var quranNavigationCallbacks: QuranNavigationCallbacks? = null
     private lateinit var guz2IndexViewModel: Guz2IndexViewModel
@@ -55,8 +56,8 @@ class Guz2IndexFragment : Fragment(), IndexItemClickListener {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentGuz2IndexBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentGuz2IndexBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -71,7 +72,7 @@ class Guz2IndexFragment : Fragment(), IndexItemClickListener {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     guz2IndexViewModel.uiState.collect { uiState ->
-                        binding!!.guz2IndexProgressBar.visibility =
+                        binding.guz2IndexProgressBar.visibility =
                             if (uiState.loading) View.VISIBLE else View.GONE
                         adapter!!.setHizbQuarterDataModels(uiState.items.toMutableList())
                     }
@@ -86,16 +87,16 @@ class Guz2IndexFragment : Fragment(), IndexItemClickListener {
     }
 
     private fun initGuz2IndexRecyclerView() {
-        binding!!.rvGuz2Index.setHasFixedSize(true)
+        binding.rvGuz2Index.setHasFixedSize(true)
         val layoutManager = LinearLayoutManager(context)
-        binding!!.rvGuz2Index.layoutManager = layoutManager
+        binding.rvGuz2Index.layoutManager = layoutManager
         val dividerItemDecoration = DividerItemDecoration(
             requireContext(),
             layoutManager.orientation
         )
-        binding!!.rvGuz2Index.addItemDecoration(dividerItemDecoration)
+        binding.rvGuz2Index.addItemDecoration(dividerItemDecoration)
         adapter = Guz2IndexAdapter(null, filterGuz2, this)
-        binding!!.rvGuz2Index.adapter = adapter
+        binding.rvGuz2Index.adapter = adapter
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -105,7 +106,7 @@ class Guz2IndexFragment : Fragment(), IndexItemClickListener {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override fun onIndexItemClick(model: HizbQuarterDataModel?, clickedItemIndex: Int) {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafBottomBarFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafBottomBarFragment.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.launch
 
 class MushafBottomBarFragment : Fragment() {
 
-    private var binding: FragmentMushafBottomBarBinding? = null
+    private var _binding: FragmentMushafBottomBarBinding? = null
+    private val binding get() = _binding!!
 
     // Shared host ViewModel: the footer wires directly to the mushaf ViewModel
     private val viewModel: MushafViewModel by viewModels({ requireParentFragment() })
@@ -46,16 +47,16 @@ class MushafBottomBarFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentMushafBottomBarBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentMushafBottomBarBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padBottomForNavigationBar(binding!!.llRoot)
+        InsetsUtils.padBottomForNavigationBar(binding.llRoot)
         initViews()
         observeViewModel()
-        binding!!.quranPageTv.text = pageNumText
+        binding.quranPageTv.text = pageNumText
     }
 
     private fun observeViewModel() {
@@ -77,19 +78,19 @@ class MushafBottomBarFragment : Fragment() {
     }
 
     private fun setupZoomButtons() {
-        binding!!.ibZoomOut.isEnabled = QuranPageZoom.canZoomOut(quranPageZoomScaleFactor)
-        binding!!.ibZoomIn.isEnabled = QuranPageZoom.canZoomIn(quranPageZoomScaleFactor)
+        binding.ibZoomOut.isEnabled = QuranPageZoom.canZoomOut(quranPageZoomScaleFactor)
+        binding.ibZoomIn.isEnabled = QuranPageZoom.canZoomIn(quranPageZoomScaleFactor)
     }
 
     @SuppressLint("ClickableViewAccessibility")
     private fun attachListeners() {
-        binding!!.llRoot.setOnTouchListener { _: View?, _: MotionEvent? ->
+        binding.llRoot.setOnTouchListener { _: View?, _: MotionEvent? ->
             true // To prevent event bubbling to the views below this one
         }
-        binding!!.quranSearchIb.setOnClickListener { onQuranSearchClick() }
-        binding!!.quranNightModeIb.setOnClickListener { onQuranNightModeClick() }
-        binding!!.ibZoomIn.setOnClickListener { zoomIn() }
-        binding!!.ibZoomOut.setOnClickListener { zoomOut() }
+        binding.quranSearchIb.setOnClickListener { onQuranSearchClick() }
+        binding.quranNightModeIb.setOnClickListener { onQuranNightModeClick() }
+        binding.ibZoomIn.setOnClickListener { zoomIn() }
+        binding.ibZoomOut.setOnClickListener { zoomOut() }
     }
 
     private fun zoomIn() {
@@ -106,26 +107,26 @@ class MushafBottomBarFragment : Fragment() {
 
     private fun setupButtonsTooltips() {
         TooltipCompat.setTooltipText(
-            binding!!.ibZoomIn,
+            binding.ibZoomIn,
             getString(R.string.tooltip_zoom_in_quran_page)
         )
         TooltipCompat.setTooltipText(
-            binding!!.ibZoomOut,
+            binding.ibZoomOut,
             getString(R.string.tooltip_zoom_out_quran_page)
         )
         TooltipCompat.setTooltipText(
-            binding!!.quranNightModeIb,
+            binding.quranNightModeIb,
             getString(R.string.tooltip_quran_night_mode)
         )
         TooltipCompat.setTooltipText(
-            binding!!.quranSearchIb,
+            binding.quranSearchIb,
             getString(R.string.tooltip_quran_search)
         )
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     private fun onQuranSearchClick() {
@@ -137,14 +138,14 @@ class MushafBottomBarFragment : Fragment() {
     }
 
     private fun setupNightModeButton(nightMode: Boolean) {
-        binding!!.quranNightModeIb.setImageResource(
+        binding.quranNightModeIb.setImageResource(
             if (nightMode) R.drawable.ic_nightmode_on else R.drawable.ic_nightmode_off
         )
     }
 
     fun setCurrentPage(pageNumText: String) {
         this.pageNumText = pageNumText
-        binding?.quranPageTv?.text = pageNumText
+        _binding?.quranPageTv?.text = pageNumText
     }
 
     interface QuranFooterCallbacks {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafTopBarFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafTopBarFragment.kt
@@ -17,7 +17,8 @@ import app.quranhub.util.InsetsUtils
 
 class MushafTopBarFragment : Fragment() {
 
-    private var binding: FragmentMushafTopBarBinding? = null
+    private var _binding: FragmentMushafTopBarBinding? = null
+    private val binding get() = _binding!!
 
     private var toolbarActionsListener: ToolbarActionsListener? = null
     private var pageDirLiveData: MutableLiveData<Int>? = null
@@ -38,18 +39,18 @@ class MushafTopBarFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentMushafTopBarBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentMushafTopBarBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.llRoot)
+        InsetsUtils.padTopForStatusBar(binding.llRoot)
         initViews()
         pageDirLiveData!!.observe(viewLifecycleOwner) { pageDir: Int? ->
             when (pageDir) {
-                PAGE_DIR_RIGHT -> binding!!.ivPageDir.setImageResource(R.drawable.ic_quran_page_right)
-                PAGE_DIR_LEFT -> binding!!.ivPageDir.setImageResource(R.drawable.ic_quran_page_left)
+                PAGE_DIR_RIGHT -> binding.ivPageDir.setImageResource(R.drawable.ic_quran_page_right)
+                PAGE_DIR_LEFT -> binding.ivPageDir.setImageResource(R.drawable.ic_quran_page_left)
                 else -> throw IllegalArgumentException("Invalid page dir")
             }
         }
@@ -57,22 +58,22 @@ class MushafTopBarFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     @SuppressLint("ClickableViewAccessibility")
     private fun initViews() {
-        TooltipCompat.setTooltipText(binding!!.ivPageDir, getText(R.string.tooltip_page_dir))
-        binding!!.llRoot.setOnTouchListener { v: View?, event: MotionEvent? ->
+        TooltipCompat.setTooltipText(binding.ivPageDir, getText(R.string.tooltip_page_dir))
+        binding.llRoot.setOnTouchListener { v: View?, event: MotionEvent? ->
             true // To prevent event bubbling to the views below this one
         }
         attachListeners()
     }
 
     private fun attachListeners() {
-        binding!!.ivMenu.setOnClickListener { onNavHamburgerClick() }
-        binding!!.btnPageGuz2.setOnClickListener { onGuz2Click() }
-        binding!!.btnPageSura.setOnClickListener { onSuraClick() }
+        binding.ivMenu.setOnClickListener { onNavHamburgerClick() }
+        binding.btnPageGuz2.setOnClickListener { onGuz2Click() }
+        binding.btnPageSura.setOnClickListener { onSuraClick() }
     }
 
     private fun onNavHamburgerClick() {
@@ -88,11 +89,11 @@ class MushafTopBarFragment : Fragment() {
     }
 
     fun setSuraText(suraName: String?) {
-        binding!!.btnPageSura.text = suraName
+        binding.btnPageSura.text = suraName
     }
 
     fun setGuz2Text(currentGuz2: String?) {
-        binding!!.btnPageGuz2.text = currentGuz2
+        binding.btnPageGuz2.text = currentGuz2
     }
 
     /**

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MyNotesFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MyNotesFragment.kt
@@ -37,7 +37,8 @@ import kotlinx.coroutines.launch
 
 class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelectionListener<Int?> {
 
-    private var binding: FragmentMyNotesBinding? = null
+    private var _binding: FragmentMyNotesBinding? = null
+    private val binding get() = _binding!!
 
     private var navDrawerListener: ToolbarActionsListener? = null
     private var quranNavigationCallbacks: QuranNavigationCallbacks? = null
@@ -65,13 +66,13 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentMyNotesBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentMyNotesBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         savedInstanceState?.let { getPrevState(it) }
         initViews()
         bindViewModel()
@@ -80,10 +81,10 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
     }
 
     private fun attachListeners() {
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
-        binding!!.editBtn.setOnClickListener { onNoteEdit() }
-        binding!!.filterBtn.setOnClickListener { onClickFilter() }
-        binding!!.ibFinishEdit.setOnClickListener { onFinishEdit() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.editBtn.setOnClickListener { onNoteEdit() }
+        binding.filterBtn.setOnClickListener { onClickFilter() }
+        binding.ibFinishEdit.setOnClickListener { onFinishEdit() }
     }
 
     private fun getPrevState(savedInstanceState: Bundle) {
@@ -107,14 +108,14 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.uiState.collect { uiState ->
-                        binding!!.progreesBar.visibility =
+                        binding.progreesBar.visibility =
                             if (uiState.loading) View.VISIBLE else View.GONE
                         val notesChanged = uiState.notes != lastRenderedNotes
                         renderNotes(uiState.notes)
                         lastRenderedNotes = uiState.notes
                         applyListState(uiState.searchQuery, uiState.filterType, notesChanged)
                         applyEditMode(uiState.isEditMode)
-                        binding!!.noNotesTv.visibility =
+                        binding.noNotesTv.visibility =
                             if (uiState.notes.isEmpty()) View.VISIBLE else View.GONE
                         applyToolbarIconsState(uiState.isListEditable)
                     }
@@ -168,35 +169,35 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
             lastAppliedEditMode = isEditMode
             adapter!!.setEditable(isEditMode)
             if (isEditMode) {
-                binding!!.ibFinishEdit.visibility = View.VISIBLE
-                binding!!.editBtn.visibility = View.GONE
-                binding!!.filterBtn.visibility = View.GONE
+                binding.ibFinishEdit.visibility = View.VISIBLE
+                binding.editBtn.visibility = View.GONE
+                binding.filterBtn.visibility = View.GONE
             } else {
-                binding!!.ibFinishEdit.visibility = View.GONE
-                binding!!.editBtn.visibility = View.VISIBLE
-                binding!!.filterBtn.visibility = View.VISIBLE
+                binding.ibFinishEdit.visibility = View.GONE
+                binding.editBtn.visibility = View.VISIBLE
+                binding.filterBtn.visibility = View.VISIBLE
             }
         }
     }
 
     private fun applyToolbarIconsState(isListEditable: Boolean) {
         if (isListEditable) {
-            binding!!.editBtn.setImageResource(R.drawable.edit_gold_ic)
-            binding!!.editBtn.setColorFilter(null)
-            binding!!.filterBtn.setColorFilter(null)
+            binding.editBtn.setImageResource(R.drawable.edit_gold_ic)
+            binding.editBtn.setColorFilter(null)
+            binding.filterBtn.setColorFilter(null)
         } else {
-            binding!!.editBtn.setImageResource(R.drawable.edit_gold_ic)
-            binding!!.editBtn.setColorFilter(
+            binding.editBtn.setImageResource(R.drawable.edit_gold_ic)
+            binding.editBtn.setColorFilter(
                 ContextCompat.getColor(requireContext(), R.color.dark_grey)
             )
-            binding!!.filterBtn.setColorFilter(
+            binding.filterBtn.setColorFilter(
                 ContextCompat.getColor(requireContext(), R.color.dark_grey)
             )
         }
     }
 
     private fun observeSearchInput() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 viewModel.onSearchQueryChanged(s.toString())
@@ -208,8 +209,8 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
 
     private fun initViews() {
         adapter = NotesAdapter(requireContext(), this)
-        binding!!.notesRv.layoutManager = LinearLayoutManager(activity)
-        binding!!.notesRv.adapter = adapter
+        binding.notesRv.layoutManager = LinearLayoutManager(activity)
+        binding.notesRv.adapter = adapter
     }
 
     private fun onNavHamburgerClick() {
@@ -217,7 +218,7 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
     }
 
     override fun onNavigateToAya(ayaId: Int, pageNum: Int) {
-        dismissKeyboard(requireContext(), binding!!.etSearch)
+        dismissKeyboard(requireContext(), binding.etSearch)
         quranNavigationCallbacks!!.gotoQuranPageAya(pageNum, ayaId, false)
     }
 
@@ -284,6 +285,6 @@ class MyNotesFragment : Fragment(), NoteCallback, AddNoteListener, ItemSelection
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranTopicsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranTopicsFragment.kt
@@ -28,7 +28,8 @@ import kotlinx.coroutines.launch
 
 class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
 
-    private var binding: FragmentQuranTopicsBinding? = null
+    private var _binding: FragmentQuranTopicsBinding? = null
+    private val binding get() = _binding!!
 
     private var adapter: SubjectsAdapter? = null
     private lateinit var viewModel: SubjectsViewModel
@@ -46,13 +47,13 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentQuranTopicsBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentQuranTopicsBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         intiRecycler()
         bindViewModel()
         attachListeners()
@@ -60,11 +61,11 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
 
     private fun attachListeners() {
         observeOnInputSearch()
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 filter(s.toString())
@@ -77,7 +78,7 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
     private fun filter(inputQuery: String) {
         if (inputQuery.isEmpty()) {
             adapter = SubjectsAdapter(topicModels, this)
-            binding!!.topicsRv.adapter = adapter
+            binding.topicsRv.adapter = adapter
         } else {
             val filteredList: MutableList<TopicModel?> = ArrayList()
             for (row in topicModels!!) {
@@ -91,7 +92,7 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
                 }
             }
             adapter = SubjectsAdapter(filteredList, this)
-            binding!!.topicsRv.adapter = adapter
+            binding.topicsRv.adapter = adapter
         }
     }
 
@@ -105,12 +106,12 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
-                    binding!!.progreesBar.visibility =
+                    binding.progreesBar.visibility =
                         if (state.loading) View.VISIBLE else View.GONE
                     state.subjects?.let { topicModels ->
                         this@QuranTopicsFragment.topicModels = topicModels
                         adapter = SubjectsAdapter(topicModels, this@QuranTopicsFragment)
-                        binding!!.topicsRv.adapter = adapter
+                        binding.topicsRv.adapter = adapter
                     }
                 }
             }
@@ -119,7 +120,7 @@ class QuranTopicsFragment : Fragment(), ItemSelectionListener<TopicCategory> {
 
     private fun intiRecycler() {
         topicModels = ArrayList()
-        binding!!.topicsRv.layoutManager = LinearLayoutManager(activity)
+        binding.topicsRv.layoutManager = LinearLayoutManager(activity)
     }
 
     override fun onSelectItem(category: TopicCategory) {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SearchFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SearchFragment.kt
@@ -34,7 +34,8 @@ import kotlinx.coroutines.launch
 class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
     OptionDialog.ItemClickListener, OptionsListDialogFragment.ItemSelectionListener {
 
-    private var binding: FragmentSearchBinding? = null
+    private var _binding: FragmentSearchBinding? = null
+    private val binding get() = _binding!!
 
     private var isOriented = false
     private var isFilterOptionsShow = false
@@ -68,13 +69,13 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentSearchBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentSearchBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         if (savedInstanceState != null) {
             isOriented = true
             getPrevState(savedInstanceState)
@@ -87,41 +88,41 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
 
     private fun attachListeners() {
         observeOnInputSearch()
-        binding!!.ibClearSearch.setOnClickListener { clearSearch() }
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
-        binding!!.filterContainer.partContainer.setOnClickListener { onClickPartFilter() }
-        binding!!.filterContainer.suraContainer.setOnClickListener { onClickSuraFilter() }
-        binding!!.filterContainer.hezbContainer.setOnClickListener { onClickHezbFilter() }
-        binding!!.filterContainer.rob3Container.setOnClickListener { onClickQuarterFilter() }
-        binding!!.moreIv.setOnClickListener { onGetMoreFilterOptions() }
+        binding.ibClearSearch.setOnClickListener { clearSearch() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.filterContainer.partContainer.setOnClickListener { onClickPartFilter() }
+        binding.filterContainer.suraContainer.setOnClickListener { onClickSuraFilter() }
+        binding.filterContainer.hezbContainer.setOnClickListener { onClickHezbFilter() }
+        binding.filterContainer.rob3Container.setOnClickListener { onClickQuarterFilter() }
+        binding.moreIv.setOnClickListener { onGetMoreFilterOptions() }
     }
 
     private fun setViewsFromBackStack() {
         if (isFilterOptionsShow) {
-            binding!!.filterContainer.root.visibility = View.VISIBLE
+            binding.filterContainer.root.visibility = View.VISIBLE
         }
         if (selectedSura != 0) {
-            binding!!.filterContainer.suraTv.text =
+            binding.filterContainer.suraTv.text =
                 requireActivity().resources.getStringArray(R.array.sura_name)[selectedSura - 1]
         }
         if (selectedJuz != 0) {
-            binding!!.filterContainer.chapterTv.text = refactorOptionText(
+            binding.filterContainer.chapterTv.text = refactorOptionText(
                 requireActivity().resources.getStringArray(R.array.agza2_name)[selectedJuz - 1]
             )
         }
         if (selectedHezb != 0) {
-            binding!!.filterContainer.hezbTv.text =
+            binding.filterContainer.hezbTv.text =
                 requireActivity().resources.getStringArray(R.array.hezb_name)[selectedHezb - 1]
         }
         if (selectedQuarter != 0) {
-            binding!!.filterContainer.rob3Tv.text =
+            binding.filterContainer.rob3Tv.text =
                 requireActivity().resources.getStringArray(R.array.quarter_name)[selectedQuarter - 1]
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -134,7 +135,7 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 inputSearch = s.toString()
@@ -146,9 +147,9 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
 
                 // show or hide clear button in search field
                 if (TextUtils.isEmpty(s)) {
-                    binding!!.ibClearSearch.visibility = View.INVISIBLE
+                    binding.ibClearSearch.visibility = View.INVISIBLE
                 } else {
-                    binding!!.ibClearSearch.visibility = View.VISIBLE
+                    binding.ibClearSearch.visibility = View.VISIBLE
                 }
             }
 
@@ -157,7 +158,7 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
     }
 
     private fun clearSearch() {
-        binding!!.etSearch.text.clear()
+        binding.etSearch.text.clear()
     }
 
     private fun searchAya() {
@@ -191,8 +192,8 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
 
     private fun clearResult() {
         searchAdapter!!.setSearchModels(ArrayList())
-        binding!!.noresultTv.visibility = View.VISIBLE
-        binding!!.progreesBar.visibility = View.GONE
+        binding.noresultTv.visibility = View.VISIBLE
+        binding.progreesBar.visibility = View.GONE
     }
 
     private fun initViewModel() {
@@ -201,13 +202,13 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     searchViewModel.uiState.collect { state ->
-                        binding!!.progreesBar.visibility =
+                        binding.progreesBar.visibility =
                             if (state.loading) View.VISIBLE else View.GONE
                         val results = state.results ?: return@collect
                         if (results.isEmpty()) {
                             clearResult()
                         } else if (inputSearch!!.trim().isNotEmpty()) {
-                            binding!!.noresultTv.visibility = View.GONE
+                            binding.noresultTv.visibility = View.GONE
                             searchAdapter!!.setSearchModels(results)
                         }
                     }
@@ -224,7 +225,7 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
                     searchViewModel.events.collect { event ->
                         when (event) {
                             is SearchViewModel.SearchEvent.ShowError -> {
-                                binding!!.progreesBar.visibility = View.GONE
+                                binding.progreesBar.visibility = View.GONE
                                 Toast.makeText(activity, event.message, Toast.LENGTH_LONG).show()
                             }
                         }
@@ -244,8 +245,8 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
 
     private fun initRecycler() {
         searchAdapter = SearchAdapter(requireContext(), this)
-        binding!!.searchRv.layoutManager = LinearLayoutManager(activity)
-        binding!!.searchRv.adapter = searchAdapter
+        binding.searchRv.layoutManager = LinearLayoutManager(activity)
+        binding.searchRv.adapter = searchAdapter
     }
 
     private fun getPrevState(savedInstanceState: Bundle) {
@@ -255,20 +256,20 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
         selectedHezb = savedInstanceState.getInt("input_hezb")
         selectedQuarter = savedInstanceState.getInt("input_qurater")
         if (selectedJuz != 0) {
-            binding!!.filterContainer.chapterTv.text = refactorOptionText(
+            binding.filterContainer.chapterTv.text = refactorOptionText(
                 requireActivity().resources.getStringArray(R.array.agza2_name)[selectedJuz - 1]
             )
         }
         if (selectedSura != 0) {
-            binding!!.filterContainer.suraTv.text =
+            binding.filterContainer.suraTv.text =
                 requireActivity().resources.getStringArray(R.array.sura_name)[selectedSura - 1]
         }
         if (selectedHezb != 0) {
-            binding!!.filterContainer.hezbTv.text =
+            binding.filterContainer.hezbTv.text =
                 requireActivity().resources.getStringArray(R.array.hezb_name)[selectedHezb - 1]
         }
         if (selectedQuarter != 0) {
-            binding!!.filterContainer.rob3Tv.text =
+            binding.filterContainer.rob3Tv.text =
                 requireActivity().resources.getStringArray(R.array.quarter_name)[selectedQuarter - 1]
         }
     }
@@ -356,25 +357,25 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
     }
 
     override fun onSelectItem(item: SearchModel) {
-        dismissKeyboard(requireContext(), binding!!.etSearch)
+        dismissKeyboard(requireContext(), binding.etSearch)
         quranNavigationCallbacks!!.gotoQuranPageAya(item.page, item.id, true)
     }
 
     override fun onItemClick(optionName: String?, optionIndex: Int, requestCode: Int) {
         if (requestCode == SURA_FILTER_CODE) {
-            binding!!.filterContainer.suraTv.text = optionName
+            binding.filterContainer.suraTv.text = optionName
             selectedSura = if (selectedJuz == 0) optionIndex else juzSuraNumbers!![optionIndex]
             searchAya()
         } else if (requestCode == JUZ_FILTER_CODE) {
-            binding!!.filterContainer.chapterTv.text =
+            binding.filterContainer.chapterTv.text =
                 if (optionIndex == 0) optionName else refactorOptionText(optionName)
-            binding!!.filterContainer.suraTv.text = getString(R.string.sura)
+            binding.filterContainer.suraTv.text = getString(R.string.sura)
             selectedSura = 0
             if (optionIndex == 0) {
                 selectedQuarter = 0
                 selectedHezb = 0
-                binding!!.filterContainer.rob3Tv.text = getString(R.string.rub3)
-                binding!!.filterContainer.hezbTv.text = getString(R.string.hizb)
+                binding.filterContainer.rob3Tv.text = getString(R.string.rub3)
+                binding.filterContainer.hezbTv.text = getString(R.string.hizb)
             } else {
                 searchViewModel.getChapterSuras(optionIndex)
             }
@@ -392,24 +393,24 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
     override fun onItemSelected(requestCode: Int, itemIndex: Int) {
         if (requestCode == HEZB_FILTER_CODE) {
             selectedHezb = itemIndex
-            binding!!.filterContainer.hezbTv.text = hezbOptions!![itemIndex]
+            binding.filterContainer.hezbTv.text = hezbOptions!![itemIndex]
             if (selectedHezb == 0) {
                 selectedQuarter = 0
-                binding!!.filterContainer.rob3Tv.text = getString(R.string.rub3)
+                binding.filterContainer.rob3Tv.text = getString(R.string.rub3)
             }
             searchAya()
         } else if (requestCode == QUARTER_FILTER_CODE) {
             selectedQuarter = itemIndex
-            binding!!.filterContainer.rob3Tv.text = quarterOptions!![itemIndex]
+            binding.filterContainer.rob3Tv.text = quarterOptions!![itemIndex]
             searchAya()
         }
     }
 
     private fun onGetMoreFilterOptions() {
         if (isFilterOptionsShow) {
-            binding!!.filterContainer.root.visibility = View.GONE
+            binding.filterContainer.root.visibility = View.GONE
         } else {
-            binding!!.filterContainer.root.visibility = View.VISIBLE
+            binding.filterContainer.root.visibility = View.VISIBLE
         }
         isFilterOptionsShow = !isFilterOptionsShow
     }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraGuz2IndexFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraGuz2IndexFragment.kt
@@ -29,7 +29,8 @@ class SuraGuz2IndexFragment : Fragment(),
     private var inputSearch: String? = ""
     private var selectedGUZ2Filter = Guz2IndexAdapter.FILTER_GUZ2_ALL
 
-    private var binding: FragmentSuraGuz2IndexBinding? = null
+    private var _binding: FragmentSuraGuz2IndexBinding? = null
+    private val binding get() = _binding!!
 
     val currentSearchQuery: String?
         get() = inputSearch
@@ -54,13 +55,13 @@ class SuraGuz2IndexFragment : Fragment(),
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentSuraGuz2IndexBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentSuraGuz2IndexBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         restoreSavedInstanceState(savedInstanceState)
         addIndexFragment(selectedTab)
         attachListeners()
@@ -69,13 +70,13 @@ class SuraGuz2IndexFragment : Fragment(),
     private fun attachListeners() {
         listenOnSelectedTab()
         observeOnInputSearch()
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
-        binding!!.filterBtn.setOnClickListener { onFilterButtonClick() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.filterBtn.setOnClickListener { onFilterButtonClick() }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     override fun onDetach() {
@@ -99,10 +100,10 @@ class SuraGuz2IndexFragment : Fragment(),
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                if (binding!!.tabLayout.selectedTabPosition == SURA_INDEX_TAB && suraIndexFragment != null) {
+                if (binding.tabLayout.selectedTabPosition == SURA_INDEX_TAB && suraIndexFragment != null) {
                     inputSearch = s.toString()
                     suraIndexFragment!!.onSearchSura(inputSearch)
                 }
@@ -113,9 +114,9 @@ class SuraGuz2IndexFragment : Fragment(),
     }
 
     private fun listenOnSelectedTab() {
-        binding!!.tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
+        binding.tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
-                addIndexFragment(binding!!.tabLayout.selectedTabPosition)
+                addIndexFragment(binding.tabLayout.selectedTabPosition)
             }
 
             override fun onTabUnselected(tab: TabLayout.Tab) {}
@@ -125,7 +126,7 @@ class SuraGuz2IndexFragment : Fragment(),
 
     private fun addIndexFragment(tab: Int) {
         selectedTab = tab
-        binding!!.tabLayout.getTabAt(selectedTab)!!.select()
+        binding.tabLayout.getTabAt(selectedTab)!!.select()
         if (tab == SURA_INDEX_TAB) {
             suraIndexFragment =
                 childFragmentManager.findFragmentByTag(FRAGMENT_SURA_INDEX) as SuraIndexFragment?
@@ -135,8 +136,8 @@ class SuraGuz2IndexFragment : Fragment(),
                     .replace(R.id.index_container, suraIndexFragment!!, FRAGMENT_SURA_INDEX)
                     .commit()
             }
-            binding!!.filterBtn.visibility = View.INVISIBLE
-            binding!!.etSearch.visibility = View.VISIBLE
+            binding.filterBtn.visibility = View.INVISIBLE
+            binding.etSearch.visibility = View.VISIBLE
         } else if (tab == GUZ2_INDEX_TAB) {
             guz2IndexFragment =
                 childFragmentManager.findFragmentByTag(FRAGMENT_GUZ2_INDEX) as Guz2IndexFragment?
@@ -146,10 +147,10 @@ class SuraGuz2IndexFragment : Fragment(),
                     .replace(R.id.index_container, guz2IndexFragment!!, FRAGMENT_GUZ2_INDEX)
                     .commit()
             }
-            binding!!.filterBtn.visibility = View.VISIBLE
-            binding!!.etSearch.text.clear()
+            binding.filterBtn.visibility = View.VISIBLE
+            binding.etSearch.text.clear()
             inputSearch = ""
-            binding!!.etSearch.visibility = View.GONE
+            binding.etSearch.visibility = View.GONE
         }
     }
 
@@ -158,7 +159,7 @@ class SuraGuz2IndexFragment : Fragment(),
     }
 
     private fun onFilterButtonClick() {
-        if (binding!!.tabLayout.selectedTabPosition == GUZ2_INDEX_TAB && guz2IndexFragment != null) {
+        if (binding.tabLayout.selectedTabPosition == GUZ2_INDEX_TAB && guz2IndexFragment != null) {
             val guz2Options: MutableList<String?> = ArrayList()
             guz2Options.add(getString(R.string.all_guz2))
             guz2Options.addAll(Arrays.asList(*resources.getStringArray(R.array.agza2_name)))

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraIndexFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraIndexFragment.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.launch
 
 class SuraIndexFragment : Fragment(), ItemSelectionListener<Int> {
 
-    private var binding: FragmentSuraIndexBinding? = null
+    private var _binding: FragmentSuraIndexBinding? = null
+    private val binding get() = _binding!!
 
     private var quranNavigationCallbacks: QuranNavigationCallbacks? = null
     private lateinit var viewModel: SuraIndexViewModel
@@ -49,8 +50,8 @@ class SuraIndexFragment : Fragment(), ItemSelectionListener<Int> {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentSuraIndexBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentSuraIndexBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -62,11 +63,11 @@ class SuraIndexFragment : Fragment(), ItemSelectionListener<Int> {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.uiState.collect { uiState ->
-                        binding!!.suraIndexProgressBar.visibility =
+                        binding.suraIndexProgressBar.visibility =
                             if (uiState.loading) View.VISIBLE else View.GONE
                         if (!uiState.loading) {
                             adapter!!.setSuraIndexModelList(uiState.items)
-                            binding!!.suraIndexRv.recycledViewPool.clear()
+                            binding.suraIndexRv.recycledViewPool.clear()
                             currentQuery?.let { adapter!!.filter(it) }
                         }
                     }
@@ -75,7 +76,7 @@ class SuraIndexFragment : Fragment(), ItemSelectionListener<Int> {
                     viewModel.suraIndexEvents.collect { event ->
                         when (event) {
                             is SuraIndexViewModel.SuraIndexEvent.NavigateToSura -> {
-                                dismissKeyboard(requireActivity(), binding!!.root)
+                                dismissKeyboard(requireActivity(), binding.root)
                                 quranNavigationCallbacks!!.gotoQuranPage(event.page)
                             }
 
@@ -89,9 +90,9 @@ class SuraIndexFragment : Fragment(), ItemSelectionListener<Int> {
     }
 
     private fun initRecycler() {
-        binding!!.suraIndexRv.layoutManager = LinearLayoutManager(activity)
+        binding.suraIndexRv.layoutManager = LinearLayoutManager(activity)
         adapter = SuraIndexAdapter(requireActivity(), this)
-        binding!!.suraIndexRv.adapter = adapter
+        binding.suraIndexRv.adapter = adapter
     }
 
     fun onSearchSura(inputQuery: String?) {
@@ -105,6 +106,6 @@ class SuraIndexFragment : Fragment(), ItemSelectionListener<Int> {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TafseerFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TafseerFragment.kt
@@ -37,7 +37,8 @@ import kotlinx.coroutines.launch
 class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationSelectionListener,
     OptionsListDialogFragment.ItemSelectionListener {
 
-    private var binding: FragmentTafseerBinding? = null
+    private var _binding: FragmentTafseerBinding? = null
+    private val binding get() = _binding!!
 
     private var inputSearch: String? = ""
     private var navDrawerListener: ToolbarActionsListener? = null
@@ -60,13 +61,13 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentTafseerBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentTafseerBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         readArgumentsData()
         savedInstanceState?.let { getPrevState(it) }
         initRecycler()
@@ -76,17 +77,17 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
 
     private fun attachListeners() {
         observeOnInputSearch()
-        binding!!.filterSuraBtn.setOnClickListener { onOpenSuraFilter() }
-        binding!!.filterBookBtn.setOnClickListener { onOpenBooksFilter() }
-        binding!!.filterLangBtn.setOnClickListener { onOpenLangFilter() }
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.filterSuraBtn.setOnClickListener { onOpenSuraFilter() }
+        binding.filterBookBtn.setOnClickListener { onOpenBooksFilter() }
+        binding.filterLangBtn.setOnClickListener { onOpenLangFilter() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
     }
 
     private fun getPrevState(savedInstanceState: Bundle) {
         inputSearch = savedInstanceState.getString("input_search")
         suraName = savedInstanceState.getString("sura_name")
         suraNumber = savedInstanceState.getInt("sura_number")
-        binding!!.suraTv.text = suraName
+        binding.suraTv.text = suraName
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -98,9 +99,9 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
 
     private fun initRecycler() {
         adapter = TafseerAdapter(requireActivity())
-        binding!!.tafseerRv.layoutManager = LinearLayoutManager(activity)
-        binding!!.tafseerRv.setHasFixedSize(true)
-        binding!!.tafseerRv.adapter = adapter
+        binding.tafseerRv.layoutManager = LinearLayoutManager(activity)
+        binding.tafseerRv.setHasFixedSize(true)
+        binding.tafseerRv.adapter = adapter
     }
 
     private fun bindViewModel() {
@@ -124,17 +125,17 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
     }
 
     private fun renderUiState(uiState: TafseerViewModel.TafseerUiState) {
-        binding!!.progreesBar.visibility = if (uiState.loading) View.VISIBLE else View.GONE
-        uiState.bookName?.let { bookName -> binding!!.bookTv.text = bookName }
+        binding.progreesBar.visibility = if (uiState.loading) View.VISIBLE else View.GONE
+        uiState.bookName?.let { bookName -> binding.bookTv.text = bookName }
         if (uiState.loading) {
             return
         }
         val tafseerModels = uiState.tafseerItems
         adapter!!.setTafseerModelList(tafseerModels)
         if (ayaNumber <= tafseerModels.size) {
-            binding!!.tafseerRv.scrollToPosition(ayaNumber - 1)
+            binding.tafseerRv.scrollToPosition(ayaNumber - 1)
         } else {
-            binding!!.tafseerRv.scrollToPosition(0)
+            binding.tafseerRv.scrollToPosition(0)
         }
         if (inputSearch != null && !TextUtils.isEmpty(inputSearch!!.trim { it <= ' ' })) {
             adapter!!.filter(inputSearch!!)
@@ -144,8 +145,8 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
     private fun renderEvent(event: TafseerViewModel.TafseerEvent) {
         when (event) {
             is TafseerViewModel.TafseerEvent.NoDownloadedBooks -> {
-                binding!!.progreesBar.visibility = View.GONE
-                binding!!.bookTv.text = getString(R.string.choose_book)
+                binding.progreesBar.visibility = View.GONE
+                binding.bookTv.text = getString(R.string.choose_book)
                 Toast.makeText(activity, getString(R.string.no_downloaded_books), Toast.LENGTH_LONG)
                     .show()
             }
@@ -156,7 +157,7 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 adapter!!.filter(s.toString())
@@ -174,12 +175,12 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
             bookDbName = requireArguments().getString(ARG_BOOK_DB_NAME)
             bookName = requireArguments().getString(ARG_BOOK_NAME)
             ayaNumber = requireArguments().getInt("ARG_AYA_NUMBER")
-            binding!!.suraTv.text = suraName
+            binding.suraTv.text = suraName
         }
         val currentTranslationLanguageIndex = Constants.Language.CODES.indexOf(
             getQuranTranslationLanguage(requireContext())
         )
-        binding!!.langTv.text = getString(
+        binding.langTv.text = getString(
             Constants.Language.NAMES_STR_IDS[currentTranslationLanguageIndex]
         )
     }
@@ -230,18 +231,18 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
         val langCode = Constants.Language.CODES[itemIndex]
         persistQuranTranslationLanguage(requireContext(), langCode)
         viewModel.onTranslationLanguageChanged(langCode)
-        binding!!.langTv.text =
+        binding.langTv.text =
             getString(Constants.Language.NAMES_STR_IDS[itemIndex])
         onOpenBooksFilter()
     }
 
     override fun onItemClick(optionName: String?, optionIndex: Int, requestCode: Int) {
-        binding!!.etSearch.text.clear()
+        binding.etSearch.text.clear()
         suraName = optionName
         suraNumber = optionIndex + 1
         ayaNumber = 1
         viewModel.onSuraSelected(suraNumber)
-        binding!!.suraTv.text = suraName
+        binding.suraTv.text = suraName
     }
 
     companion object {

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TopicAyasFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TopicAyasFragment.kt
@@ -28,7 +28,8 @@ import kotlinx.coroutines.launch
 
 class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
 
-    private var binding: FragmentTopicAyasBinding? = null
+    private var _binding: FragmentTopicAyasBinding? = null
+    private val binding get() = _binding!!
 
     private var inputSearch: String? = ""
     private var quranNavigationCallbacks: QuranNavigationCallbacks? = null
@@ -51,13 +52,13 @@ class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentTopicAyasBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentTopicAyasBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         setViews()
         getPrevState(savedInstanceState)
         intiRecycler()
@@ -67,7 +68,7 @@ class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
 
     private fun attachListeners() {
         observeOnInputSearch()
-        binding!!.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+        binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
     }
 
     private fun getPrevState(savedInstanceState: Bundle?) {
@@ -83,11 +84,11 @@ class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
 
     private fun setViews() {
         category = requireArguments().getParcelable(CATEGORY_ARGS)
-        binding!!.topicTv.text = category?.categoryName
+        binding.topicTv.text = category?.categoryName
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 inputSearch = s.toString()
@@ -104,7 +105,7 @@ class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
-                    binding!!.progreesBar.visibility =
+                    binding.progreesBar.visibility =
                         if (state.loading) View.VISIBLE else View.GONE
                     state.ayahs?.let { ayahs ->
                         adapter!!.setSearchModels(ayahs)
@@ -118,13 +119,13 @@ class TopicAyasFragment : Fragment(), ItemSelectionListener<SearchModel> {
     }
 
     private fun intiRecycler() {
-        binding!!.topicsRv.layoutManager = LinearLayoutManager(activity)
+        binding.topicsRv.layoutManager = LinearLayoutManager(activity)
         adapter = SearchAdapter(requireActivity(), this)
-        binding!!.topicsRv.adapter = adapter
+        binding.topicsRv.adapter = adapter
     }
 
     override fun onSelectItem(item: SearchModel) {
-        dismissKeyboard(requireContext(), binding!!.etSearch)
+        dismissKeyboard(requireContext(), binding.etSearch)
         quranNavigationCallbacks!!.gotoQuranPageAya(item.page, item.id, false)
     }
 

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsDataFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsDataFragment.kt
@@ -38,7 +38,8 @@ class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.Ite
 
     private var languageCode: String? = null
     private var listener: TranslationSelectionListener? = null
-    private var binding: FragmentTranslationsDataBinding? = null
+    private var _binding: FragmentTranslationsDataBinding? = null
+    private val binding get() = _binding!!
     private var adapter: TranslationsAdapter? = null
 
     private val viewModel: TranslationsViewModel by viewModels {
@@ -71,27 +72,27 @@ class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.Ite
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentTranslationsDataBinding.inflate(inflater, container, false)
+        _binding = FragmentTranslationsDataBinding.inflate(inflater, container, false)
         initView()
-        return binding!!.root
+        return binding.root
     }
 
     private fun initView() {
         // setup translationsRecyclerView
-        binding!!.rvTranslations.setHasFixedSize(true)
+        binding.rvTranslations.setHasFixedSize(true)
         val layoutManager = LinearLayoutManager(context)
-        binding!!.rvTranslations.layoutManager = layoutManager
+        binding.rvTranslations.layoutManager = layoutManager
         val dividerItemDecoration = DividerItemDecoration(
             requireContext(),
             layoutManager.orientation
         )
-        binding!!.rvTranslations.addItemDecoration(dividerItemDecoration)
+        binding.rvTranslations.addItemDecoration(dividerItemDecoration)
         adapter = TranslationsAdapter(
             ArrayList<DisplayableTranslation>(),
             getQuranTranslationBook(requireContext()),
             this
         )
-        binding!!.rvTranslations.adapter = adapter
+        binding.rvTranslations.adapter = adapter
         observeViewModel()
     }
 
@@ -100,7 +101,7 @@ class TranslationsDataFragment : Fragment(), Searchable, TranslationsAdapter.Ite
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
                     viewModel.uiState.collect { state ->
-                        binding!!.progressTranslation.visibility =
+                        binding.progressTranslation.visibility =
                             if (state.loading) View.VISIBLE else View.GONE
                         adapter!!.setTranslations(state.translations.toMutableList())
                     }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsLibraryFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TranslationsLibraryFragment.kt
@@ -23,7 +23,8 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
     private var inputSearch: String? = ""
     private var navDrawerListener: ToolbarActionsListener? = null
 
-    private var binding: FragmentTranslationsLibraryBinding? = null
+    private var _binding: FragmentTranslationsLibraryBinding? = null
+    private val binding get() = _binding!!
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -36,13 +37,13 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentTranslationsLibraryBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentTranslationsLibraryBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        InsetsUtils.padTopForStatusBar(binding!!.toolbarLayout)
+        InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         restoreSavedInstanceState(savedInstanceState)
         addFragment()
         attachListeners()
@@ -50,7 +51,7 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
 
     private fun attachListeners() {
         observeOnInputSearch()
-        binding!!.hamburgerIv.setOnClickListener { v: View? -> onNavHamburgerClick() }
+        binding.hamburgerIv.setOnClickListener { v: View? -> onNavHamburgerClick() }
     }
 
     private fun restoreSavedInstanceState(savedInstanceState: Bundle?) {
@@ -65,7 +66,7 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
     }
 
     private fun observeOnInputSearch() {
-        binding!!.etSearch.addTextChangedListener(object : TextWatcher {
+        binding.etSearch.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 inputSearch = s.toString()
@@ -77,7 +78,7 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
     }
 
     private fun addFragment() {
-        binding!!.etSearch.text.clear()
+        binding.etSearch.text.clear()
         inputSearch = ""
 
         translationsDataFragment =
@@ -103,7 +104,7 @@ class TranslationsLibraryFragment : Fragment(), TranslationSelectionListener {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/app/quranhub/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/settings/SettingsFragment.kt
@@ -31,7 +31,8 @@ import kotlinx.coroutines.launch
 class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionListener,
     ReciterSelectionListener {
 
-    private var binding: FragmentSettingsBinding? = null
+    private var _binding: FragmentSettingsBinding? = null
+    private val binding get() = _binding!!
 
     private val viewModel: SettingsViewModel by viewModels {
         viewModelFactory {
@@ -45,8 +46,8 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentSettingsBinding.inflate(inflater, container, false)
-        return binding!!.root
+        _binding = FragmentSettingsBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -57,7 +58,7 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
 
     override fun onDestroyView() {
         super.onDestroyView()
-        binding = null
+        _binding = null
     }
 
     private fun observeViewModel() {
@@ -92,7 +93,7 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
     }
 
     private fun setSettingsViewsListeners() {
-        binding!!.settingAppLang.setOnClickListener {
+        binding.settingAppLang.setOnClickListener {
             val appLangDialog = OptionsListDialogFragment.getInstance(
                 getString(R.string.app_lang_setting_dialog_title),
                 Constants.Language.NAMES_STR_IDS,
@@ -103,7 +104,7 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
                 requireActivity().supportFragmentManager, "AppLangDialog"
             )
         }
-        binding!!.settingTranslationLang.setOnClickListener {
+        binding.settingTranslationLang.setOnClickListener {
             val translationLangDialog = OptionsListDialogFragment.getInstance(
                 getString(R.string.translation_lang_setting_dialog_title),
                 Constants.Language.NAMES_STR_IDS,
@@ -114,19 +115,19 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
                 requireActivity().supportFragmentManager, "TransLangDialog"
             )
         }
-        binding!!.settingScreenReadingBacklight.setOnCheckedChangeListener(object :
+        binding.settingScreenReadingBacklight.setOnCheckedChangeListener(object :
             MushafSettingSwitch.OnCheckedChangeListener {
             override fun onCheckedChanged(settingSwitch: MushafSettingSwitch, checked: Boolean) {
                 viewModel.onScreenReadingBacklightChanged(checked)
             }
         })
-        binding!!.settingLastReadPage.setOnCheckedChangeListener(object :
+        binding.settingLastReadPage.setOnCheckedChangeListener(object :
             MushafSettingSwitch.OnCheckedChangeListener {
             override fun onCheckedChanged(settingSwitch: MushafSettingSwitch, checked: Boolean) {
                 viewModel.onLastReadPageChanged(checked)
             }
         })
-        binding!!.settingRecitation.setOnClickListener {
+        binding.settingRecitation.setOnClickListener {
             val recitationDialog = OptionsListDialogFragment.getInstance(
                 resources.getString(R.string.recitation_setting_dialog_title),
                 Constants.Recitation.NAMES_STR_IDS,
@@ -136,24 +137,24 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
             )
             recitationDialog.show(requireActivity().supportFragmentManager, "RecitationDialog")
         }
-        binding!!.settingQuranReader.setOnClickListener {
+        binding.settingQuranReader.setOnClickListener {
             val recitationId = viewModel.uiState.value.recitationIndex
             val reciterId = viewModel.uiState.value.reciterId
             val recitersDialog = QuranRecitersDialogFragment
                 .newInstance(recitationId, reciterId)
             recitersDialog.show(childFragmentManager, "QuranRecitersDialogFragment")
         }
-        binding!!.settingAudioDownloadManager.setOnClickListener {
+        binding.settingAudioDownloadManager.setOnClickListener {
             startActivity(Intent(requireContext(), DownloadsManagerActivity::class.java))
         }
-        binding!!.settingAboutAppVersion.setOnClickListener {
+        binding.settingAboutAppVersion.setOnClickListener {
             // TODO aboutAppVersionSetting click listener
             Toast.makeText(
                 requireContext(), "v" + BuildConfig.VERSION_NAME,
                 Toast.LENGTH_SHORT
             ).show()
         }
-        binding!!.settingShareApp.setOnClickListener {
+        binding.settingShareApp.setOnClickListener {
             // TODO shareAppSetting click listener
             val shareIntent = Intent(Intent.ACTION_SEND)
             shareIntent.type = "text/plain"


### PR DESCRIPTION
## Summary
Standardizes ViewBinding access across the codebase on the pattern already used by `QuranPageFragment`:

```kotlin
private var _binding: FragmentXBinding? = null
private val binding get() = _binding!!
```

- Replaced nullable `private var binding: …Binding? = null` with `_binding` + a non-null `binding` accessor in **32 files** (fragments, dialogs, `AyaAudioPopup`, `FirstTimeWizardActivity`).
- All scattered `binding!!` accesses are now plain `binding` calls.
- Assignment sites updated accordingly (`_binding = …inflate(...)`, `_binding = null` in `onDestroyView`/`onDestroy`).

## NPE-safety preserved
Post-teardown call sites that previously relied on nullable safety keep it:
- `QuranRecitersDialogFragment.render`: `val binding = _binding ?: return`
- `MushafBottomBarFragment.setCurrentPage` and `AudioDownloadAmountDialogFragment` observers: `_binding?.…`
- Deliberately untouched: `QuranPageFragment`, `MushafFragment`, `DownloadsQuranImagesFragment` (already on the pattern), adapter ViewHolders (`binding = …bind(itemView)` lifecycle), and `DownloadsManagerActivity` (`lateinit`, no `!!` usage).

No behavior change: call sites that would have crashed via `binding!!` behave identically; previously-safe call sites remain safe.

## Verification
- `./gradlew :app:compileDebugKotlin` passes.