### PR TITLE
fix: enable core library desugaring to fix Supplier CNFE crash on API 23

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+        isCoreLibraryDesugaringEnabled = true
     }
 
     buildFeatures {
@@ -67,6 +68,8 @@ room {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     // Misc.
     implementation(libs.core.ktx)
     implementation(libs.appcompat)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ spectrum = "0.7.1"
 viewpager = "1.1.0"
 firebaseBom = "34.18.0"
 glide = "5.0.9"
+desugarJdkLibs = "2.1.5"
 lifecycle = "2.11.0"
 material = "1.14.0"
 materialdrawer = "v6.1.3"
@@ -73,6 +74,7 @@ firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glide" }
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 materialdrawer = { module = "com.github.mikepenz:MaterialDrawer", version.ref = "materialdrawer" }
 prdownloader = { module = "com.github.amitshekhariitbhu:PRDownloader", version.ref = "prdownloader" }


### PR DESCRIPTION
## Summary

Fixes the top fatal crash on Firebase Crashlytics (issue `736e8a5cbe44d90ff1d64baa5b9bcb60`, first seen in 1.8.0):

```
java.lang.ClassNotFoundException: Didn't find class "java.util.function.Supplier"
  at com.bumptech.glide.load.engine.DecodeJob.init (DecodeJob.java:159)
  at com.bumptech.glide.request.SingleRequest.begin
  at app.quranhub.ui.mushaf.fragments.QuranPageFragment.showQuranPage
```

## Root cause

Glide 5.0.9 references `java.util.function.Supplier`, which only exists on **API 24+**. The app's `minSdk` is 23, so on Android 6 devices every Glide image load (e.g. loading a Quran page image in `QuranPageFragment`) crashes as soon as a decode job starts. Crash rate is amplified by page loads being the core app path; Crashlytics flags it as fresh (appeared ~2 days ago with 1.8.0) and repetitive (~4 crashes per user).

## Fix

Enable core library desugaring so the `java.util.function` backport ships in the APK for API 23 devices:

- `gradle/libs.versions.toml`: add `desugarJdkLibs = "2.1.5"` + `desugar-jdk-libs` entry
- `app/build.gradle.kts`: `isCoreLibraryDesugaringEnabled = true` + `coreLibraryDesugaring(...)` dependency

## Verification

- `./gradlew build` passes (what CI runs)
- Inspected dexes of both debug and release APKs: the backport is present and Glide's `Supplier` supertype reference is rewritten by D8/R8

Related: #283