### PR TITLE
fix: guard drawActionShadow against empty aya list to fix audio-state crash

### DIFF
--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranPageFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranPageFragment.kt
@@ -540,14 +540,19 @@ class QuranPageFragment : Fragment(), AyaPropertiesListener, AddNoteListener,
 
     // draw shadow when user make prev or next action on aya
     fun drawActionShadow(isClickPrev: Boolean) {
-        if (pageAyasList == null) return
+        val ayas = pageAyasList ?: return
+        // Audio state events can arrive before this page's ayas finish
+        // loading (or with a stale index) — bail out instead of crashing.
+        if (ayas.isEmpty()) return
         if (isClickPrev) {
-            previousAya = if (currentAyaIndex - 1 > 0) pageAyasList!![currentAyaIndex - 2] else null
-            currentAya = pageAyasList!![currentAyaIndex - 1]
+            if (currentAyaIndex !in 1..ayas.size) return
+            previousAya = if (currentAyaIndex - 1 > 0) ayas[currentAyaIndex - 2] else null
+            currentAya = ayas[currentAyaIndex - 1]
             currentAyaIndex--
         } else {
-            previousAya = pageAyasList!![currentAyaIndex]
-            currentAya = pageAyasList!![currentAyaIndex + 1]
+            if (currentAyaIndex >= ayas.size - 1) return
+            previousAya = ayas[currentAyaIndex]
+            currentAya = ayas[currentAyaIndex + 1]
             currentAyaIndex++
         }
         drawShadow()


### PR DESCRIPTION
## Summary

Fixes the fatal `java.lang.IndexOutOfBoundsException` reported in Crashlytics (issue `44d47400a13bd95281224e2c54108fc0`, seen in v1.7.0–1.8.0).

**Root cause:** `MushafFragment.onAudioStateChanged` reacts to `PLAY_NEXT`/`COMPLETED` audio events (via `AudioPlaybackStateHolder`) by calling `QuranPageFragment.drawActionShadow(false)`. If the addressed page fragment's ayas had not finished loading (`pageAyasList` empty — e.g. right after paging/recycling), `pageAyasList[currentAyaIndex]` read an empty `ArrayList`, crashing the app.

**Fix:** `drawActionShadow` now:
- bails out if the aya list is null or empty
- bounds-checks `currentAyaIndex` in both the prev (`in 1..size`) and next (`< size-1`) branches before indexing

## Testing

- `:app:compileDebugKotlin` → BUILD SUCCESSFUL
- Verified crash stack against [Crashlytics issue](https://console.firebase.google.com/project/quranhub/crashlytics/app/1:37290313887:android:99ce31802f56215e26faaa/issues/44d47400a13bd95281224e2c54108fc0)