### PR TITLE
fix: guard onAyaAudioNotFound against detached fragment to fix audio-state crash

### DIFF
--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/MushafFragment.kt
@@ -429,6 +429,7 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        quranPageFragment = null
         if (AppPreferencesManager.getScreenReadingBacklightSetting(requireContext())) {
             // re-enable the screen timeout
             keepScreenOn(requireActivity(), false)
@@ -493,12 +494,23 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
     }
 
     private fun setCurrentQuranPageFragment() {
-        if (quranPageFragment == null) {
-            quranPageFragment = binding.quranViewpager.adapter?.instantiateItem(
-                binding.quranViewpager,
-                binding.quranViewpager.currentItem
-            ) as? QuranPageFragment
+        val cached = quranPageFragment
+        if (cached != null && cached.isAdded && !cached.isDetached) return
+        // Cached page is stale (detached/recycled after notifyDataSetChanged with
+        // POSITION_NONE, or left over from a destroyed view) — re-resolve it.
+        // Audio state events arriving in between must not act on a detached page.
+        val binding = _binding ?: run {
+            quranPageFragment = null
+            return
         }
+        val adapter = binding.quranViewpager.adapter ?: run {
+            quranPageFragment = null
+            return
+        }
+        quranPageFragment = adapter.instantiateItem(
+            binding.quranViewpager,
+            binding.quranViewpager.currentItem
+        ) as? QuranPageFragment
     }
 
     private fun setPageDir() {
@@ -1075,7 +1087,16 @@ class MushafFragment : Fragment(), QuranFooterCallbacks, TranslationSelectionLis
                     checkAyaRecorderState(quranPageFragment!!.currentAyaId)
                 }
             }
-            AudioPlaybackState.NOT_DOWNLOADED -> quranPageFragment!!.onAyaAudioNotFound()
+            AudioPlaybackState.NOT_DOWNLOADED -> {
+                // setCurrentQuranPageFragment above already drops stale refs;
+                // double-guard here — onAyaAudioNotFound needs an attached
+                // page (requireContext/dialogs), audio events can win the race
+                // with paging/recycling.
+                val pageFragment = quranPageFragment
+                if (pageFragment != null && pageFragment.isAdded && !pageFragment.isDetached) {
+                    pageFragment.onAyaAudioNotFound()
+                }
+            }
             AudioPlaybackState.GROUP_REPEAT_COMPLETED -> swipToFirstAyaInRepeatGroup()
         }
     }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranPageFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranPageFragment.kt
@@ -720,9 +720,15 @@ class QuranPageFragment : Fragment(), AyaPropertiesListener, AddNoteListener,
     }
 
     fun onAyaAudioNotFound() {
+        // Audio state events can arrive after this page was detached/recycled
+        // (ViewPager POSITION_NONE recreates fragments, stale cached refs) —
+        // bail out instead of crashing on requireContext().
+        if (!isSafeFragment(this)) return
+        if (childFragmentManager.isStateSaved) return
         mushafFragment?.togglePauseState(false)
         isAyaAudioDownloaded = false
-        val reciterId = AppPreferencesManager.getReciterSheikhSetting(requireContext())
+        val ctx = context ?: return
+        val reciterId = AppPreferencesManager.getReciterSheikhSetting(ctx)
         if (reciterId != null) {
             openDownloadAmountDialog(reciterId)
         } else {


### PR DESCRIPTION
## Summary

Fixes the fatal `java.lang.IllegalStateException: Fragment not attached to a context` reported in Crashlytics issue `fbafeaccda39e04cf0ca4b83c7fe160c` (v1.8.0, 5 events).

**Root cause:** `MushafFragment.onAudioStateChanged` reacts to `NOT_DOWNLOADED` audio events (via `AudioPlaybackStateHolder`) by calling `QuranPageFragment.onAyaAudioNotFound`, which calls `requireContext()`. If the cached page fragment was detached/recycled — `QuranViewPagerAdapter` returns `POSITION_NONE` so `notifyDataSetChanged()` recreates fragments, plus the cached ref survived `onDestroyView` — `requireContext()` throws.

**Fix:**
- `QuranPageFragment.onAyaAudioNotFound` bails out when the fragment isn't safe (`isSafeFragment`), state is saved, or `context` is null; uses safe `context` instead of `requireContext()`.
- `MushafFragment.setCurrentQuranPageFragment` re-resolves stale detached refs (and nulls safely when view/adapter is gone) instead of reusing them forever.
- `MushafFragment.onAudioStateChanged` (`NOT_DOWNLOADED`) double-guards with `isAdded`/`isDetached` before delegating.
- `MushafFragment.onDestroyView` clears the cached page ref.

Follows the same defensive pattern as #288 (`drawActionShadow` empty-list guard) for audio-state events racing paging/recycling.

## Testing

- `:app:compileDebugKotlin` → BUILD SUCCESSFUL
- `./gradlew build` (what CI runs) → BUILD SUCCESSFUL
- Verified crash stack against [Crashlytics issue](https://console.firebase.google.com/project/quranhub/crashlytics/app/1:37290313887:android:99ce31802f56215e26faaa/issues/fbafeaccda39e04cf0ca4b83c7fe160c)
