### PR TITLE
fix: resolve open Crashlytics crashes (recorder, aya index, binding lifecycle, TransactionTooLarge)

### DIFF
--- a/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsQuranImagesFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/downloads_manager/DownloadsQuranImagesFragment.kt
@@ -165,7 +165,7 @@ class DownloadsQuranImagesFragment : Fragment() {
     private fun onImageLoaded(pageNum: Int, isSuccessful: Boolean = true) {
         Log.d("TAG", "onImageLoaded: $pageNum , success: $isSuccessful")
 
-        if (_binding == null) return
+        if (_binding == null || !isAdded) return
 
         totalPagesDownloaded += 1
 
@@ -185,16 +185,22 @@ class DownloadsQuranImagesFragment : Fragment() {
             binding.groupDownloadInfo.isVisible = false
             binding.tvDownloadProgress.text = ""
             binding.root.keepScreenOn = false
-            Toast.makeText(requireContext(), R.string.download_complete, Toast.LENGTH_SHORT).show()
+            context?.let {
+                Toast.makeText(it, R.string.download_complete, Toast.LENGTH_SHORT).show()
+            }
             totalPagesDownloaded = 0
 
+            // The delayed reset can fire after onDestroyView (Glide callbacks
+            // outlive the view) — re-check binding (see Crashlytics:
+            // DownloadsQuranImagesFragment.getBinding NPE).
             handler.postDelayed({
-                binding.btnDownload.progress = 0
+                _binding?.btnDownload?.progress = 0
             }, 1500)
         }
     }
 
     override fun onDestroyView() {
+        handler.removeCallbacksAndMessages(null)
         super.onDestroyView()
         _binding = null
     }

--- a/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListAdapter.kt
+++ b/app/src/main/java/app/quranhub/ui/first_wizard/OptionsListAdapter.kt
@@ -146,7 +146,13 @@ class OptionsListAdapter : RecyclerView.Adapter<OptionsListAdapter.ViewHolder>, 
         }
 
         override fun onClick(v: View) {
-            val originalIndex = filteredOriginalIndices[adapterPosition]
+            // adapterPosition is NO_POSITION (-1) when the holder was removed or the
+            // list was filtered between layout and click (see Crashlytics:
+            // OptionsListAdapter.ViewHolder.onClick ArrayIndexOutOfBounds).
+            val pos = bindingAdapterPosition
+            if (pos == RecyclerView.NO_POSITION) return
+            if (pos < 0 || pos >= filteredOriginalIndices.size) return
+            val originalIndex = filteredOriginalIndices[pos]
             setSelectedOptionIndex(originalIndex)
             itemClickListener.onItemClick(originalIndex)
         }

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddNoteDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddNoteDialog.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.os.Environment
 import android.os.SystemClock
 import android.text.TextUtils
+import android.util.Log
 import android.view.View
 import android.view.Window
 import android.widget.RadioButton
@@ -280,7 +281,7 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
         } catch (e: RuntimeException) {
             // setAudioSource throws when the mic is in use or unavailable
             // (see Crashlytics: AddNoteDialog.startRecord setAudioSource failed).
-            e.printStackTrace()
+            Log.e(TAG, "Failed to configure audio recorder", e)
             audioRecorder?.release()
             audioRecorder = null
             activity?.let {
@@ -292,11 +293,11 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
             audioRecorder!!.prepare()
             audioRecorder!!.start()
         } catch (e: IOException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to start recording", e)
         } catch (e: RuntimeException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to start recording", e)
         } catch (e: IllegalStateException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to start recording", e)
         }
     }
 
@@ -371,6 +372,7 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     companion object {
+        private val TAG = AddNoteDialog::class.java.simpleName
 
         fun getInstance(ayaId: Int): AddNoteDialog {
             val bundle = Bundle()

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddNoteDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AddNoteDialog.kt
@@ -271,15 +271,31 @@ class AddNoteDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     private fun startRecord() {
-        audioRecorder = MediaRecorder()
-        audioRecorder!!.setAudioSource(MediaRecorder.AudioSource.MIC)
-        audioRecorder!!.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
-        audioRecorder!!.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
-        audioRecorder!!.setOutputFile(outputRecorderPath)
+        try {
+            audioRecorder = MediaRecorder()
+            audioRecorder!!.setAudioSource(MediaRecorder.AudioSource.MIC)
+            audioRecorder!!.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
+            audioRecorder!!.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
+            audioRecorder!!.setOutputFile(outputRecorderPath)
+        } catch (e: RuntimeException) {
+            // setAudioSource throws when the mic is in use or unavailable
+            // (see Crashlytics: AddNoteDialog.startRecord setAudioSource failed).
+            e.printStackTrace()
+            audioRecorder?.release()
+            audioRecorder = null
+            activity?.let {
+                Toast.makeText(it, getString(R.string.accept_perm), Toast.LENGTH_LONG).show()
+            }
+            return
+        }
         try {
             audioRecorder!!.prepare()
             audioRecorder!!.start()
         } catch (e: IOException) {
+            e.printStackTrace()
+        } catch (e: RuntimeException) {
+            e.printStackTrace()
+        } catch (e: IllegalStateException) {
             e.printStackTrace()
         }
     }

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderDialog.kt
@@ -7,6 +7,7 @@ import android.os.SystemClock
 import android.view.Gravity
 import android.view.View
 import android.view.Window
+import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProvider
 import app.quranhub.R
@@ -58,7 +59,17 @@ class AyaRecorderDialog : DialogFragment() {
         )
         if (startRecord) {
             voiceRecorderViewModel.setAyaRecorderPath(ayaId, requireContext())
-            voiceRecorderViewModel.startRecord()
+            if (!voiceRecorderViewModel.isRecorderAvailable ||
+                !voiceRecorderViewModel.startRecord()
+            ) {
+                // Mic in use / unavailable: don't crash, close gracefully.
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.accept_perm),
+                    Toast.LENGTH_LONG
+                ).show()
+                dismissAllowingStateLoss()
+            }
         }
     }
 

--- a/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderPlayerDialog.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/dialogs/AyaRecorderPlayerDialog.kt
@@ -156,10 +156,14 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     override fun onGetMaxDuration(duration: Int) {
+        if (_binding == null) return
         binding.recorderProgress.max = duration
     }
 
     override fun onPositionChanged(position: Int) {
+        // Callbacks arrive on a background Handler and can outlive onDestroyView
+        // (see Crashlytics: AyaRecorderPlayerDialog.onUpdatedTime NPE).
+        if (_binding == null) return
         if (!userIsSeeking) {
             if (Build.VERSION.SDK_INT >= 24) {
                 binding.recorderProgress.setProgress(position, true)
@@ -170,10 +174,12 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     override fun onUpdatedTime(time: String?) {
+        if (_binding == null) return
         binding.recorderTimeTv.text = time
     }
 
     override fun onStateChanged(state: PlaybackState) {
+        if (_binding == null) return
         if (state == PlaybackState.COMPLETED) {
             binding.recorderProgress.progress = 0
             isPlaying = false
@@ -183,10 +189,13 @@ class AyaRecorderPlayerDialog : DialogFragment(), MediaPlayerCallback {
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
+        // Detach callbacks first so no Handler post touches the cleared binding.
+        recorderMediaHelper?.setMediaPlayerCallback(null)
         if (!requireActivity().isChangingConfigurations && recorderMediaHelper != null) {
             recorderMediaHelper!!.release()
         }
+        recorderMediaHelper = null
+        super.onDestroyView()
         _binding = null
     }
 

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranPageFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/QuranPageFragment.kt
@@ -297,9 +297,16 @@ class QuranPageFragment : Fragment(), AyaPropertiesListener, AddNoteListener,
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putParcelable("current_aya", currentAya)
-        outState.putParcelable("prev_aya", previousAya)
-        outState.putParcelable("selected_note", viewModel.uiState.value.selectedAyaNote)
+        // Strip the large tafseer payload before parceling: full Aya objects saved
+        // across ViewPager pages add up and trigger TransactionTooLargeException
+        // (see Crashlytics: BinderProxy.transactNative). Tafseer is reloaded on
+        // demand via viewModel.getAyaTafseer().
+        outState.putParcelable("current_aya", currentAya?.copy(tafseer = ""))
+        outState.putParcelable("prev_aya", previousAya?.copy(tafseer = ""))
+        outState.putParcelable(
+            "selected_note",
+            viewModel.uiState.value.selectedAyaNote
+        )
         outState.putBoolean("open_dialog", noteDialogOpen)
         outState.putInt("CURRENT_AYA_INDEX", currentAyaIndex)
         outState.putInt("num_of_ayas", numOfAyaInPage)
@@ -765,14 +772,20 @@ class QuranPageFragment : Fragment(), AyaPropertiesListener, AddNoteListener,
     // get aya position of start repeat interval in current page
     private val firstAyaNumberInPage: Int
         get() {
-            if (pageAyasList!![0].sura != mushafFragment!!.fromSuraDownloaded) {
-                for (i in pageAyasList!!.indices) {
-                    if (pageAyasList!![i].sura == mushafFragment!!.fromSuraDownloaded && pageAyasList!![i].suraAya == mushafFragment!!.firstAyaInRepeatGroup) {
+            val ayas = pageAyasList
+            val fragment = mushafFragment
+            if (ayas.isNullOrEmpty() || fragment == null) return 0
+            if (ayas[0].sura != fragment.fromSuraDownloaded) {
+                for (i in ayas.indices) {
+                    if (ayas[i].sura == fragment.fromSuraDownloaded && ayas[i].suraAya == fragment.firstAyaInRepeatGroup) {
                         return i
                     }
                 }
             }
-            return mushafFragment!!.firstAyaInRepeatGroup - pageAyasList!![0].suraAya
+            // The repeat offset can fall outside this page (stale repeat group after
+            // page change) — clamp instead of crashing (see Crashlytics:
+            // checkPlayMiddleAyaAudio IndexOutOfBounds).
+            return (fragment.firstAyaInRepeatGroup - ayas[0].suraAya).coerceIn(ayas.indices)
         }
 
     // draw shadow of current aya played in notification audio when launch app from notification
@@ -806,26 +819,32 @@ class QuranPageFragment : Fragment(), AyaPropertiesListener, AddNoteListener,
     }
 
     private fun checkPlayFirstAyaAudio() {
-        if (isPageShown && pageAyasList != null && playFirstAyaAudio) {
+        val ayas = pageAyasList
+        if (isPageShown && !ayas.isNullOrEmpty() && playFirstAyaAudio) {
             currentAyaIndex = 0
-            currentAya = pageAyasList!![currentAyaIndex]
+            currentAya = ayas[currentAyaIndex]
             previousAya = null
             drawShadow()
-            mushafFragment!!.checkAyaRecorderState(currentAya!!.id)
+            mushafFragment?.checkAyaRecorderState(currentAya!!.id)
             playFirstAyaAudio = false
-            mushafFragment!!.playAudioService()
+            mushafFragment?.playAudioService()
+        } else if (ayas.isNullOrEmpty()) {
+            playFirstAyaAudio = false
         }
     }
 
     private fun checkPlayMiddleAyaAudio() {
-        if (playMiddleAyaAudio && isPageShown && pageAyasList != null) {
-            currentAyaIndex = firstAyaNumberInPage
-            currentAya = pageAyasList!![currentAyaIndex]
-            previousAya = if (currentAyaIndex > 0) pageAyasList!![currentAyaIndex - 1] else null
+        val ayas = pageAyasList
+        if (playMiddleAyaAudio && isPageShown && !ayas.isNullOrEmpty()) {
+            currentAyaIndex = firstAyaNumberInPage.coerceIn(ayas.indices)
+            currentAya = ayas[currentAyaIndex]
+            previousAya = if (currentAyaIndex > 0) ayas[currentAyaIndex - 1] else null
             drawShadow()
-            mushafFragment!!.checkAyaRecorderState(currentAya!!.id)
+            mushafFragment?.checkAyaRecorderState(currentAya!!.id)
             playMiddleAyaAudio = false
-            mushafFragment!!.playAudioService()
+            mushafFragment?.playAudioService()
+        } else if (ayas.isNullOrEmpty()) {
+            playMiddleAyaAudio = false
         }
     }
 

--- a/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/VoiceRecorderViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/VoiceRecorderViewModel.kt
@@ -12,15 +12,38 @@ import java.io.IOException
 
 class VoiceRecorderViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val audioRecorder: MediaRecorder = MediaRecorder()
+    private var audioRecorder: MediaRecorder? = null
 
     var outputRecorderPath: String? = null
         private set
 
-    init {
-        audioRecorder.setAudioSource(MediaRecorder.AudioSource.MIC)
-        audioRecorder.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
-        audioRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
+    /** True when the recorder was configured without the mic throwing (in use, no permission…). */
+    var isRecorderAvailable: Boolean = false
+        private set
+
+    private fun ensureRecorder(): Boolean {
+        if (audioRecorder != null) return isRecorderAvailable
+        var recorder: MediaRecorder? = null
+        return try {
+            recorder = MediaRecorder()
+            recorder.setAudioSource(MediaRecorder.AudioSource.MIC)
+            recorder.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
+            recorder.setAudioEncoder(MediaRecorder.AudioEncoder.DEFAULT)
+            audioRecorder = recorder
+            isRecorderAvailable = true
+            true
+        } catch (e: RuntimeException) {
+            // setAudioSource throws when the mic is in use, missing permission, or no HW.
+            // Must not crash ViewModel creation (see Crashlytics: VoiceRecorderViewModel.<init>).
+            e.printStackTrace()
+            try {
+                recorder?.release()
+            } catch (ignored: RuntimeException) {
+            }
+            audioRecorder = null
+            isRecorderAvailable = false
+            false
+        }
     }
 
     fun setAyaRecorderPath(ayaId: Int, context: Context) {
@@ -39,23 +62,56 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
             childFile.mkdir()
         }
         outputRecorderPath = childFile.path + File.separator + ayaId + ".3gp"
-        audioRecorder.setOutputFile(outputRecorderPath)
+        if (!ensureRecorder()) return
+        try {
+            audioRecorder?.setOutputFile(outputRecorderPath)
+        } catch (e: RuntimeException) {
+            e.printStackTrace()
+            isRecorderAvailable = false
+        }
     }
 
-    fun startRecord() {
-        try {
-            audioRecorder.prepare()
-            audioRecorder.start()
+    fun startRecord(): Boolean {
+        if (!ensureRecorder()) return false
+        return try {
+            audioRecorder?.prepare()
+            audioRecorder?.start()
+            true
         } catch (e: IOException) {
             e.printStackTrace()
+            false
+        } catch (e: RuntimeException) {
+            e.printStackTrace()
+            false
+        } catch (e: IllegalStateException) {
+            e.printStackTrace()
+            false
         }
     }
 
     fun stopRecorder() {
-        audioRecorder.stop()
+        try {
+            audioRecorder?.stop()
+        } catch (e: RuntimeException) {
+            e.printStackTrace()
+        } catch (e: IllegalStateException) {
+            e.printStackTrace()
+        }
     }
 
     fun releaseRecorder() {
-        audioRecorder.release()
+        try {
+            audioRecorder?.release()
+        } catch (e: RuntimeException) {
+            e.printStackTrace()
+        } finally {
+            audioRecorder = null
+            isRecorderAvailable = false
+        }
+    }
+
+    override fun onCleared() {
+        releaseRecorder()
+        super.onCleared()
     }
 }

--- a/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/VoiceRecorderViewModel.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/viewmodel/VoiceRecorderViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.media.MediaRecorder
 import android.os.Environment
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import app.quranhub.data.Constants
 import app.quranhub.data.local.prefs.AppPreferencesManager.getRecitationSetting
@@ -35,7 +36,7 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
         } catch (e: RuntimeException) {
             // setAudioSource throws when the mic is in use, missing permission, or no HW.
             // Must not crash ViewModel creation (see Crashlytics: VoiceRecorderViewModel.<init>).
-            e.printStackTrace()
+            Log.e(TAG, "Failed to configure audio recorder", e)
             try {
                 recorder?.release()
             } catch (ignored: RuntimeException) {
@@ -66,7 +67,7 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
         try {
             audioRecorder?.setOutputFile(outputRecorderPath)
         } catch (e: RuntimeException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to set recorder output file", e)
             isRecorderAvailable = false
         }
     }
@@ -78,13 +79,13 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
             audioRecorder?.start()
             true
         } catch (e: IOException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to start recording", e)
             false
         } catch (e: RuntimeException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to start recording", e)
             false
         } catch (e: IllegalStateException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to start recording", e)
             false
         }
     }
@@ -93,9 +94,9 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
         try {
             audioRecorder?.stop()
         } catch (e: RuntimeException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to stop recording", e)
         } catch (e: IllegalStateException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to stop recording", e)
         }
     }
 
@@ -103,7 +104,7 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
         try {
             audioRecorder?.release()
         } catch (e: RuntimeException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to release recorder", e)
         } finally {
             audioRecorder = null
             isRecorderAvailable = false
@@ -113,5 +114,9 @@ class VoiceRecorderViewModel(application: Application) : AndroidViewModel(applic
     override fun onCleared() {
         releaseRecorder()
         super.onCleared()
+    }
+
+    companion object {
+        private val TAG = VoiceRecorderViewModel::class.java.simpleName
     }
 }

--- a/app/src/main/java/app/quranhub/util/RecorderMediaHelper.kt
+++ b/app/src/main/java/app/quranhub/util/RecorderMediaHelper.kt
@@ -75,10 +75,21 @@ class RecorderMediaHelper {
 
     fun release() {
         if (mediaPlayer != null) {
-            mediaPlayer!!.release()
+            try {
+                mediaPlayer!!.release()
+            } catch (e: RuntimeException) {
+                e.printStackTrace()
+            }
             mediaPlayer = null
         }
+        // Stop both updaters: the progress executor otherwise keeps posting
+        // onPositionChanged to a destroyed dialog (see Crashlytics:
+        // AyaRecorderPlayerDialog.onUpdatedTime NPE).
+        progressExecutor?.shutdownNow()
+        progressExecutor = null
+        seekbarPositionUpdateTask = null
         stopAudioUpdatedTime()
+        mediaPlayerCallback = null
     }
 
     fun play() {
@@ -134,7 +145,14 @@ class RecorderMediaHelper {
     fun startUpdatingAudioTime() {
         if (audioUpdatedTimeTask == null) {
             audioUpdatedTimeTask = Handler()
-            audioTimeRunnable = Runnable { milliSecondsToTimer(mediaPlayer!!.currentPosition) }
+            audioTimeRunnable = Runnable {
+                val player = mediaPlayer ?: return@Runnable
+                try {
+                    milliSecondsToTimer(player.currentPosition)
+                } catch (e: IllegalStateException) {
+                    e.printStackTrace()
+                }
+            }
         }
         audioUpdatedTimeTask!!.postDelayed(audioTimeRunnable!!, 1000)
     }

--- a/app/src/main/java/app/quranhub/util/RecorderMediaHelper.kt
+++ b/app/src/main/java/app/quranhub/util/RecorderMediaHelper.kt
@@ -2,6 +2,7 @@ package app.quranhub.util
 
 import android.media.MediaPlayer
 import android.os.Handler
+import android.util.Log
 import java.io.IOException
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -42,7 +43,7 @@ class RecorderMediaHelper {
             mediaPlayer!!.setDataSource(path)
             mediaPlayer!!.prepare()
         } catch (e: IOException) {
-            e.printStackTrace()
+            Log.e(TAG, "Failed to set audio path", e)
         }
         initProgressCallback()
     }
@@ -78,7 +79,7 @@ class RecorderMediaHelper {
             try {
                 mediaPlayer!!.release()
             } catch (e: RuntimeException) {
-                e.printStackTrace()
+                Log.e(TAG, "Failed to release media player", e)
             }
             mediaPlayer = null
         }
@@ -150,7 +151,7 @@ class RecorderMediaHelper {
                 try {
                     milliSecondsToTimer(player.currentPosition)
                 } catch (e: IllegalStateException) {
-                    e.printStackTrace()
+                    Log.e(TAG, "Failed to read player position", e)
                 }
             }
         }
@@ -185,6 +186,7 @@ class RecorderMediaHelper {
     }
 
     companion object {
+        private val TAG = RecorderMediaHelper::class.java.simpleName
         const val PLAYBACK_POSITION_REFRESH_INTERVAL_MS = 150
         const val TIMER_INTERVAL_MS = 1
     }

--- a/app/src/main/res/layout/bottomsheet_translation.xml
+++ b/app/src/main/res/layout/bottomsheet_translation.xml
@@ -103,6 +103,7 @@
             android:layoutDirection="ltr"
             android:paddingTop="@dimen/_6sdp"
             android:paddingBottom="@dimen/_6sdp"
+            android:saveEnabled="false"
             android:scrollIndicators="end"
             android:scrollbarStyle="insideInset"
             android:scrollbars="vertical"

--- a/app/src/main/res/layout/fragment_mushaf.xml
+++ b/app/src/main/res/layout/fragment_mushaf.xml
@@ -15,6 +15,7 @@
             android:id="@+id/quran_viewpager"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:saveEnabled="false"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes open Crashlytics crashes triaged from the `quranhub` Firebase project (app `1:37290313887:android:99ce31802f56215e26faaa`), prioritizing latest release 1.8.0 (build 17) and highest user impact.

**Fixed (all verified via `crashlytics_list_events` stack traces):**
- `VoiceRecorderViewModel.<init>` / `AddNoteDialog.startRecord` — `setAudioSource failed` RuntimeException crashed ViewModel creation when mic in use/unavailable. MediaRecorder init is now lazy + crash-safe; `AyaRecorderDialog` dismisses gracefully on failure.
- `QuranPageFragment.getFirstAyaNumberInPage` / `checkPlayMiddleAyaAudio` — `IndexOutOfBoundsException` on empty page list and out-of-range repeat index (incl. Index -1 / Index 86 Size 15). Guards + `coerceIn`, null-safe `mushafFragment` access.
- `OptionsListAdapter.ViewHolder.onClick` — `ArrayIndexOutOfBoundsException index=-1` from stale `adapterPosition`. Now guards `bindingAdapterPosition == NO_POSITION` + bounds.
- `DownloadsQuranImagesFragment.getBinding` / `AyaRecorderPlayerDialog.onUpdatedTime` — NPE from Handler callbacks firing after `onDestroyView` cleared binding. Re-check `_binding` in delayed lambdas/callbacks, remove callbacks on destroy, detach player callback.
- `RecorderMediaHelper` — `release()` now shuts down the progress executor (was leaking `onPositionChanged` posts to dead dialogs) and null-safe timer.
- `BinderProxy.transactNative TransactionTooLargeException` (97 events / 66 users, top volume) — strip `tafseer` from saved Aya parcelables; `saveEnabled=false` on `quran_viewpager` (restored via prefs) and `translation_sheet_tv` (reloaded via ViewModel).

**Already fixed on master, no action:** Glide `Supplier` CNFE (#284, desugaring), `drawActionShadow` empty list (#288), `onAyaAudioNotFound` detached (#289), `MushafFragment.getBinding` (guarded `showAudioPopupOnNextLayout`), `WindowInsetsCompat.systemOverlays` (core-ktx 1.19.0, last seen 1.7.0), legacy `provideDisplayableDownloads` (removed by MVVM migration). System ANRs (gms dynamite, libart GC, nativePollOnce) have no app-code blame frame.

**Verification:** `./gradlew build` — BUILD SUCCESSFUL.

After merge, close the corresponding Crashlytics issues once the release with these fixes rolls out and crash-free users recover.