### PR TITLE
fix: use platform WindowInsets on API 30+ to fix systemOverlays crash on API 34

### DIFF
--- a/app/src/main/java/app/quranhub/util/InsetsUtils.kt
+++ b/app/src/main/java/app/quranhub/util/InsetsUtils.kt
@@ -1,38 +1,83 @@
 package app.quranhub.util
 
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 
+/**
+ * Applies status/navigation-bar insets as padding or margin.
+ *
+ * Uses platform [WindowInsets] APIs on API 30+ and only falls back to
+ * [WindowInsetsCompat] on older releases. The compat path must be avoided on API 34:
+ * [WindowInsetsCompat.toWindowInsetsCompat] with an attached view runs
+ * `Impl20.initTypeBoundingRectsMaps`, which iterates every inset type including
+ * `SYSTEM_OVERLAYS` and calls `WindowInsets.Type.systemOverlays()` via
+ * `TypeImpl34.toPlatformType`. On devices whose framework lacks that method this throws
+ * `NoSuchMethodError` during insets dispatch, before our listener even runs
+ * (see Crashlytics: 87073ca8fd3c019e5e5bb6172c9d96e1, Pixel 8 Pro on Android 14).
+ * Requesting only statusBars/navigationBars through the platform API never touches
+ * `systemOverlays()`, so it is safe on those devices.
+ */
 object InsetsUtils {
 
     fun padTopForStatusBar(view: View) {
-        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-            v.updatePadding(top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top)
-            insets
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            view.setOnApplyWindowInsetsListener { v, insets ->
+                v.updatePadding(
+                    top = insets.getInsets(WindowInsets.Type.statusBars()).top
+                )
+                insets
+            }
+        } else {
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+                v.updatePadding(top = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top)
+                insets
+            }
         }
         ViewCompat.requestApplyInsets(view)
     }
 
     fun padBottomForNavigationBar(view: View) {
-        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-            v.updatePadding(bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom)
-            insets
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            view.setOnApplyWindowInsetsListener { v, insets ->
+                v.updatePadding(
+                    bottom = insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+                )
+                insets
+            }
+        } else {
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+                v.updatePadding(bottom = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom)
+                insets
+            }
         }
         ViewCompat.requestApplyInsets(view)
     }
 
     fun padBottomMarginForNavigationBar(view: View) {
         val baseMargin = (view.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin ?: 0
-        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-            (v.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
-                lp.bottomMargin =
-                    baseMargin + insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
-                v.layoutParams = lp
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            view.setOnApplyWindowInsetsListener { v, insets ->
+                (v.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                    lp.bottomMargin = baseMargin +
+                            insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+                    v.layoutParams = lp
+                }
+                insets
             }
-            insets
+        } else {
+            ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+                (v.layoutParams as? ViewGroup.MarginLayoutParams)?.let { lp ->
+                    lp.bottomMargin =
+                        baseMargin + insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
+                    v.layoutParams = lp
+                }
+                insets
+            }
         }
         ViewCompat.requestApplyInsets(view)
     }


### PR DESCRIPTION
## Summary
Fixes Crashlytics issue `87073ca8fd3c019e5e5bb6172c9d96e1` — fatal startup loop (`NoSuchMethodError: WindowInsets$Type.systemOverlays()`) via `WindowInsetsCompat$TypeImpl34.toPlatformType` on Pixel 8 Pro / Android 14, introduced in 1.7.0 by the edge-to-edge change (`d84fee7`) that installed `WindowInsetsCompat` listeners on every screen.

`WindowInsetsCompat.toWindowInsetsCompat(insets, view)` with an attached view runs `Impl20.initTypeBoundingRectsMaps` over **all** inset types including `SYSTEM_OVERLAYS`, touching the missing framework method during insets dispatch — before our listener even runs. core-ktx 1.19.0 is already the latest stable, so this needs an app-side workaround.

`InsetsUtils` now uses platform `View.setOnApplyWindowInsetsListener` + `WindowInsets.Type.statusBars()/navigationBars()` on API 30+ (never touches `systemOverlays()`), keeping `WindowInsetsCompat` only on API <30 where that code path doesn't exist. Covers all three helpers and all ~15 call sites.

## Testing
- `./gradlew build` — BUILD SUCCESSFUL (same as CI), no new lint findings.
- Crash data pulled via Firebase MCP (`crashlytics_get_issue` / `crashlytics_batch_get_events`); root-cause note added to the Crashlytics issue, left OPEN until a release confirms no recurrence.