### PR TITLE
fix: migrate OptionsListDialogFragment to Fragment Result API (guz2Dialog crash f7817e39)

### DIFF
--- a/app/src/main/java/app/quranhub/ui/common/dialogs/OptionsListDialogFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/common/dialogs/OptionsListDialogFragment.kt
@@ -10,7 +10,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -19,6 +18,24 @@ import app.quranhub.util.DialogUtils.adjustDialogSize
 
 /**
  * Display options as a list (single selection)
+ *
+ * Results are delivered via the Fragment Result API ([androidx.fragment.app.FragmentManager.setFragmentResult])
+ * using the [requestKey] supplied to [getInstance]. Register a listener on the same
+ * FragmentManager the dialog is shown with:
+ *
+ * ```
+ * childFragmentManager.setFragmentResultListener(REQUEST_KEY, viewLifecycleOwner) { _, bundle ->
+ *     onItemSelected(
+ *         bundle.getInt(OptionsListDialogFragment.RESULT_REQUEST_CODE),
+ *         bundle.getInt(OptionsListDialogFragment.RESULT_ITEM_INDEX)
+ *     )
+ * }
+ * ```
+ *
+ * The legacy setTargetFragment mechanism is intentionally not used: it throws
+ * IllegalStateException ("declared target fragment ... does not belong to this
+ * FragmentManager") when the dialog outlives its target (replace/navigation,
+ * process-death restore). See Crashlytics f7817e39e76b1c0284cfbeee6eb4548a.
  */
 class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClickListener {
 
@@ -26,21 +43,10 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
     private var options: List<String>? = null
     private var optionsThumbnailsDrawableIds: IntArray? = null
     private var selectedOptionIndex = 0
+    private var requestKey: String? = null
+    private var requestCode = 0
     private var _binding: DialogOptionsListBinding? = null
     private val binding get() = _binding!!
-    private var itemSelectionListener: ItemSelectionListener? = null
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        itemSelectionListener = try {
-            targetFragment as ItemSelectionListener?
-        } catch (e: ClassCastException) {
-            throw ClassCastException(
-                targetFragment!!.javaClass.simpleName
-                        + " must implement OptionsListDialogFragment#ItemSelectionListener"
-            )
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +55,8 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
             options = it.getStringArrayList(ARG_DIALOG_OPTIONS)
             optionsThumbnailsDrawableIds = it.getIntArray(ARG_DIALOG_OPTIONS_THUMBNAILS)
             selectedOptionIndex = it.getInt(ARG_SELECTED_OPTION_INDEX)
+            requestKey = it.getString(ARG_REQUEST_KEY)
+            requestCode = it.getInt(ARG_REQUEST_CODE)
         }
     }
 
@@ -94,13 +102,16 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
         _binding = null
     }
 
-    override fun onDetach() {
-        super.onDetach()
-        itemSelectionListener = null
-    }
-
     override fun onItemClick(clickedItemIndex: Int) {
-        itemSelectionListener!!.onItemSelected(targetRequestCode, clickedItemIndex)
+        requestKey?.let { key ->
+            parentFragmentManager.setFragmentResult(
+                key,
+                Bundle().apply {
+                    putInt(RESULT_REQUEST_CODE, requestCode)
+                    putInt(RESULT_ITEM_INDEX, clickedItemIndex)
+                }
+            )
+        }
         dismiss()
     }
 
@@ -109,25 +120,35 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
     }
 
     companion object {
-        private val TAG = OptionsListDialogFragment::class.java.simpleName
+        const val RESULT_REQUEST_CODE = "RESULT_REQUEST_CODE"
+        const val RESULT_ITEM_INDEX = "RESULT_ITEM_INDEX"
 
         private const val ARG_DIALOG_TITLE = "ARG_DIALOG_TITLE"
         private const val ARG_DIALOG_OPTIONS = "ARG_DIALOG_OPTIONS"
         private const val ARG_DIALOG_OPTIONS_THUMBNAILS = "ARG_DIALOG_OPTIONS_THUMBNAILS"
         private const val ARG_SELECTED_OPTION_INDEX = "ARG_SELECTED_OPTION_INDEX"
+        private const val ARG_REQUEST_KEY = "ARG_REQUEST_KEY"
+        private const val ARG_REQUEST_CODE = "ARG_REQUEST_CODE"
 
         @JvmStatic
         fun getInstance(
-            dialogTitle: String, options: List<String?>, targetFragment: Fragment, requestCode: Int
+            dialogTitle: String,
+            options: List<String?>,
+            requestKey: String,
+            requestCode: Int
         ): OptionsListDialogFragment {
-            return getInstance(dialogTitle, options, -1, targetFragment, requestCode)
+            return getInstance(dialogTitle, options, -1, requestKey, requestCode)
         }
 
         @JvmStatic
         fun getInstance(
-            dialogTitle: String, optionsResIds: IntArray, targetFragment: Fragment, requestCode: Int
+            dialogTitle: String,
+            optionsResIds: IntArray,
+            context: Context,
+            requestKey: String,
+            requestCode: Int
         ): OptionsListDialogFragment {
-            return getInstance(dialogTitle, optionsResIds, -1, targetFragment, requestCode)
+            return getInstance(dialogTitle, optionsResIds, -1, context, requestKey, requestCode)
         }
 
         @JvmStatic
@@ -135,18 +156,19 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
             dialogTitle: String,
             optionsResIds: IntArray,
             selectedOptionIndex: Int,
-            targetFragment: Fragment,
+            context: Context,
+            requestKey: String,
             requestCode: Int
         ): OptionsListDialogFragment {
             val options: MutableList<String?> = ArrayList()
             for (stringResId in optionsResIds) {
-                options.add(targetFragment.getString(stringResId))
+                options.add(context.getString(stringResId))
             }
             return getInstance(
                 dialogTitle,
                 options,
                 selectedOptionIndex,
-                targetFragment,
+                requestKey,
                 requestCode
             )
         }
@@ -156,7 +178,7 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
             dialogTitle: String,
             options: List<String?>,
             selectedOptionIndex: Int,
-            targetFragment: Fragment,
+            requestKey: String,
             requestCode: Int
         ): OptionsListDialogFragment {
             val fragment = OptionsListDialogFragment()
@@ -164,8 +186,9 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
             args.putString(ARG_DIALOG_TITLE, dialogTitle)
             args.putStringArrayList(ARG_DIALOG_OPTIONS, ArrayList(options))
             args.putInt(ARG_SELECTED_OPTION_INDEX, selectedOptionIndex)
+            args.putString(ARG_REQUEST_KEY, requestKey)
+            args.putInt(ARG_REQUEST_CODE, requestCode)
             fragment.arguments = args
-            fragment.setTargetFragment(targetFragment, requestCode)
             return fragment
         }
 
@@ -175,12 +198,13 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
             optionsResIds: IntArray,
             optionsThumbnailsDrawableIds: IntArray?,
             selectedOptionIndex: Int,
-            targetFragment: Fragment,
+            context: Context,
+            requestKey: String,
             requestCode: Int
         ): OptionsListDialogFragment {
             val options: MutableList<String> = ArrayList()
             for (stringResId in optionsResIds) {
-                options.add(targetFragment.getString(stringResId))
+                options.add(context.getString(stringResId))
             }
             val fragment = OptionsListDialogFragment()
             val args = Bundle()
@@ -188,8 +212,9 @@ class OptionsListDialogFragment : DialogFragment(), OptionsListAdapter.ItemClick
             args.putStringArrayList(ARG_DIALOG_OPTIONS, ArrayList(options))
             args.putIntArray(ARG_DIALOG_OPTIONS_THUMBNAILS, optionsThumbnailsDrawableIds)
             args.putInt(ARG_SELECTED_OPTION_INDEX, selectedOptionIndex)
+            args.putString(ARG_REQUEST_KEY, requestKey)
+            args.putInt(ARG_REQUEST_CODE, requestCode)
             fragment.arguments = args
-            fragment.setTargetFragment(targetFragment, requestCode)
             return fragment
         }
     }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SearchFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SearchFragment.kt
@@ -83,6 +83,7 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
         initRecycler()
         initViewModel()
         setViewsFromBackStack()
+        observeDialogResults()
         attachListeners()
     }
 
@@ -95,6 +96,25 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
         binding.filterContainer.hezbContainer.setOnClickListener { onClickHezbFilter() }
         binding.filterContainer.rob3Container.setOnClickListener { onClickQuarterFilter() }
         binding.moreIv.setOnClickListener { onGetMoreFilterOptions() }
+    }
+
+    private fun observeDialogResults() {
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_HEZB_FILTER, viewLifecycleOwner
+        ) { _, bundle ->
+            onItemSelected(
+                bundle.getInt(OptionsListDialogFragment.RESULT_REQUEST_CODE),
+                bundle.getInt(OptionsListDialogFragment.RESULT_ITEM_INDEX)
+            )
+        }
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_QUARTER_FILTER, viewLifecycleOwner
+        ) { _, bundle ->
+            onItemSelected(
+                bundle.getInt(OptionsListDialogFragment.RESULT_REQUEST_CODE),
+                bundle.getInt(OptionsListDialogFragment.RESULT_ITEM_INDEX)
+            )
+        }
     }
 
     private fun setViewsFromBackStack() {
@@ -329,10 +349,10 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
             getString(R.string.hizb),
             hezbOptions!!,
             selectedHezb,
-            this,
+            REQUEST_HEZB_FILTER,
             HEZB_FILTER_CODE
         )
-        fragment.show(requireActivity().supportFragmentManager, "HizbFilterDialog")
+        fragment.show(childFragmentManager, "HizbFilterDialog")
     }
 
     private fun onClickQuarterFilter() {
@@ -350,10 +370,10 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
             getString(R.string.rub3),
             quarterOptions!!,
             selectedQuarter,
-            this,
+            REQUEST_QUARTER_FILTER,
             QUARTER_FILTER_CODE
         )
-        fragment.show(requireActivity().supportFragmentManager, "QuarterFilterDialog")
+        fragment.show(childFragmentManager, "QuarterFilterDialog")
     }
 
     override fun onSelectItem(item: SearchModel) {
@@ -420,5 +440,7 @@ class SearchFragment : Fragment(), ItemSelectionListener<SearchModel>,
         const val JUZ_FILTER_CODE = 2
         const val HEZB_FILTER_CODE = 3
         const val QUARTER_FILTER_CODE = 4
+        private const val REQUEST_HEZB_FILTER = "SearchFragment:hezb_filter"
+        private const val REQUEST_QUARTER_FILTER = "SearchFragment:quarter_filter"
     }
 }

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraGuz2IndexFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/SuraGuz2IndexFragment.kt
@@ -63,6 +63,7 @@ class SuraGuz2IndexFragment : Fragment(),
         super.onViewCreated(view, savedInstanceState)
         InsetsUtils.padTopForStatusBar(binding.toolbarLayout)
         restoreSavedInstanceState(savedInstanceState)
+        observeDialogResult()
         addIndexFragment(selectedTab)
         attachListeners()
     }
@@ -72,6 +73,17 @@ class SuraGuz2IndexFragment : Fragment(),
         observeOnInputSearch()
         binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
         binding.filterBtn.setOnClickListener { onFilterButtonClick() }
+    }
+
+    private fun observeDialogResult() {
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_GUZ2_FILTER, viewLifecycleOwner
+        ) { _, bundle ->
+            onItemSelected(
+                bundle.getInt(OptionsListDialogFragment.RESULT_REQUEST_CODE),
+                bundle.getInt(OptionsListDialogFragment.RESULT_ITEM_INDEX)
+            )
+        }
     }
 
     override fun onDestroyView() {
@@ -165,9 +177,9 @@ class SuraGuz2IndexFragment : Fragment(),
             guz2Options.addAll(Arrays.asList(*resources.getStringArray(R.array.agza2_name)))
             val guz2Dialog = getInstance(
                 getString(R.string.title_options_dialog_filter_guz2_index),
-                guz2Options, selectedGUZ2Filter, this, RC_GUZ2_FILTER
+                guz2Options, selectedGUZ2Filter, REQUEST_GUZ2_FILTER, RC_GUZ2_FILTER
             )
-            guz2Dialog.show(parentFragmentManager, "guz2Dialog")
+            guz2Dialog.show(childFragmentManager, "guz2Dialog")
         }
     }
 
@@ -189,6 +201,7 @@ class SuraGuz2IndexFragment : Fragment(),
         const val SURA_INDEX_TAB = 0
         const val GUZ2_INDEX_TAB = 1
         private const val RC_GUZ2_FILTER = 0
+        private const val REQUEST_GUZ2_FILTER = "SuraGuz2IndexFragment:guz2_filter"
 
         fun newInstance(selectedTab: Int): SuraGuz2IndexFragment {
             val fragment = SuraGuz2IndexFragment()

--- a/app/src/main/java/app/quranhub/ui/mushaf/fragments/TafseerFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/mushaf/fragments/TafseerFragment.kt
@@ -72,6 +72,7 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
         savedInstanceState?.let { getPrevState(it) }
         initRecycler()
         bindViewModel()
+        observeDialogResult()
         attachListeners()
     }
 
@@ -81,6 +82,17 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
         binding.filterBookBtn.setOnClickListener { onOpenBooksFilter() }
         binding.filterLangBtn.setOnClickListener { onOpenLangFilter() }
         binding.hamburgerIv.setOnClickListener { onNavHamburgerClick() }
+    }
+
+    private fun observeDialogResult() {
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_TRANS_LANG, viewLifecycleOwner
+        ) { _, bundle ->
+            onItemSelected(
+                bundle.getInt(OptionsListDialogFragment.RESULT_REQUEST_CODE),
+                bundle.getInt(OptionsListDialogFragment.RESULT_ITEM_INDEX)
+            )
+        }
     }
 
     private fun getPrevState(savedInstanceState: Bundle) {
@@ -211,10 +223,11 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
             getString(R.string.translation_lang_setting_dialog_title),
             Constants.Language.NAMES_STR_IDS,
             currentTranslationLanguageIndex,
-            this,
+            requireContext(),
+            REQUEST_TRANS_LANG,
             RC_TRANS_LANG_SETTING
         )
-        translationLangDialog.show(parentFragmentManager, "trans_lang_dialog")
+        translationLangDialog.show(childFragmentManager, "trans_lang_dialog")
     }
 
     private fun onNavHamburgerClick() {
@@ -248,6 +261,7 @@ class TafseerFragment : Fragment(), OptionDialog.ItemClickListener, TranslationS
     companion object {
 
         private const val RC_TRANS_LANG_SETTING = 2
+        private const val REQUEST_TRANS_LANG = "TafseerFragment:trans_lang"
         private const val ARG_SURA_NAME = "ARG_SURA_NAME"
         private const val ARG_SURA_NUMBER = "ARG_PAGE_NUMBER"
         private const val ARG_BOOK_DB_NAME = "ARG_BOOK_DB_NAME"

--- a/app/src/main/java/app/quranhub/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/app/quranhub/ui/settings/SettingsFragment.kt
@@ -52,6 +52,7 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        observeDialogResults()
         setSettingsViewsListeners()
         observeViewModel()
     }
@@ -92,16 +93,38 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
         b.settingQuranReader.currentValue = state.reciterName
     }
 
+    private fun observeDialogResults() {
+        val listener =
+            { _: String, bundle: Bundle ->
+                onItemSelected(
+                    bundle.getInt(OptionsListDialogFragment.RESULT_REQUEST_CODE),
+                    bundle.getInt(OptionsListDialogFragment.RESULT_ITEM_INDEX)
+                )
+            }
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_APP_LANG, viewLifecycleOwner, listener
+        )
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_TRANS_LANG, viewLifecycleOwner, listener
+        )
+        childFragmentManager.setFragmentResultListener(
+            REQUEST_RECITATION, viewLifecycleOwner, listener
+        )
+    }
+
     private fun setSettingsViewsListeners() {
         binding.settingAppLang.setOnClickListener {
             val appLangDialog = OptionsListDialogFragment.getInstance(
                 getString(R.string.app_lang_setting_dialog_title),
                 Constants.Language.NAMES_STR_IDS,
                 Constants.Language.FLAGS_DRAWABLE_IDS,
-                viewModel.uiState.value.appLangIndex, this, RC_APP_LANG_SETTING
+                viewModel.uiState.value.appLangIndex,
+                requireContext(),
+                REQUEST_APP_LANG,
+                RC_APP_LANG_SETTING
             )
             appLangDialog.show(
-                requireActivity().supportFragmentManager, "AppLangDialog"
+                childFragmentManager, "AppLangDialog"
             )
         }
         binding.settingTranslationLang.setOnClickListener {
@@ -109,10 +132,13 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
                 getString(R.string.translation_lang_setting_dialog_title),
                 Constants.Language.NAMES_STR_IDS,
                 Constants.Language.FLAGS_DRAWABLE_IDS,
-                viewModel.uiState.value.translationLangIndex, this, RC_TRANS_LANG_SETTING
+                viewModel.uiState.value.translationLangIndex,
+                requireContext(),
+                REQUEST_TRANS_LANG,
+                RC_TRANS_LANG_SETTING
             )
             translationLangDialog.show(
-                requireActivity().supportFragmentManager, "TransLangDialog"
+                childFragmentManager, "TransLangDialog"
             )
         }
         binding.settingScreenReadingBacklight.setOnCheckedChangeListener(object :
@@ -132,10 +158,11 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
                 resources.getString(R.string.recitation_setting_dialog_title),
                 Constants.Recitation.NAMES_STR_IDS,
                 viewModel.uiState.value.recitationIndex,
-                this,
+                requireContext(),
+                REQUEST_RECITATION,
                 RC_RECITATION_SETTING
             )
-            recitationDialog.show(requireActivity().supportFragmentManager, "RecitationDialog")
+            recitationDialog.show(childFragmentManager, "RecitationDialog")
         }
         binding.settingQuranReader.setOnClickListener {
             val recitationId = viewModel.uiState.value.recitationIndex
@@ -189,5 +216,8 @@ class SettingsFragment : Fragment(), OptionsListDialogFragment.ItemSelectionList
         private const val RC_APP_LANG_SETTING = 1
         private const val RC_TRANS_LANG_SETTING = 2
         private const val RC_RECITATION_SETTING = 3
+        private const val REQUEST_APP_LANG = "SettingsFragment:app_lang"
+        private const val REQUEST_TRANS_LANG = "SettingsFragment:trans_lang"
+        private const val REQUEST_RECITATION = "SettingsFragment:recitation"
     }
 }


### PR DESCRIPTION
Fixes Crashlytics f7817e39e76b1c0284cfbeee6eb4548a (FATAL, 1.0.0-beta.5 → 1.4.0):

`IllegalStateException` in `FragmentStateManager.attach` — `OptionsListDialogFragment` (tag=guz2Dialog) declared target fragment `SuraGuz2IndexFragment` that does not belong to this FragmentManager.

Root cause: `setTargetFragment` (deprecated) keeps a hard reference to the host. When the dialog outlives its target (container `replace`/navigation, process-death restore) the framework throws on re-attach.

Change: migrate `OptionsListDialogFragment` to the Fragment Result API — dialog carries `requestKey` + `requestCode` in args and delivers via `parentFragmentManager.setFragmentResult`; all 4 callers (`SuraGuz2Index`, Search hezb/quarter, Tafseer lang, Settings app/trans/recitation) register on `childFragmentManager` and show with `childFragmentManager` so dialog lifecycle is tied to its host. No more cross-FragmentManager target reference.

Verified: `./gradlew build` — BUILD SUCCESSFUL.